### PR TITLE
make genesis read write to chunk, improve leveldb block size and buf size,

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -209,20 +209,25 @@ func initGenesis(ctx *cli.Context) error {
 	if ctx.Args().Len() != 1 {
 		utils.Fatalf("need genesis.json file as the only argument")
 	}
+	start := time.Now()
 	genesisPath := ctx.Args().First()
 	if len(genesisPath) == 0 {
 		utils.Fatalf("invalid path to genesis file")
 	}
+	log.Info("start reading genesis", "path", genesisPath)
 	file, err := os.Open(genesisPath)
 	if err != nil {
 		utils.Fatalf("Failed to read genesis file: %v", err)
 	}
 	defer file.Close()
+	log.Info("end reading genesis file...")
 
+	log.Info("start decoding genesis file into json")
 	genesis := new(core.Genesis)
 	if err := json.NewDecoder(file).Decode(genesis); err != nil {
 		utils.Fatalf("invalid genesis file: %v", err)
 	}
+	log.Info("end decoding genesis file...")
 	// Open and initialise both full and light databases
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
@@ -253,7 +258,9 @@ func initGenesis(ctx *cli.Context) error {
 	if compatErr != nil {
 		utils.Fatalf("Failed to write chain config: %v", compatErr)
 	}
-	log.Info("Successfully wrote genesis state", "database", "chaindata", "hash", hash)
+
+	elapsed := time.Since(start)
+	log.Info("Successfully wrote genesis state", "database", "chaindata", "hash", hash, "elapsed", elapsed.Minutes())
 
 	return nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"strings"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -212,10 +212,12 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database, isIsthmus bool)
 			statedb.SetState(addr, key, value)
 		}
 	}
+	log.Info("before statedb commit")
 	root, err := statedb.Commit(0, false, false)
 	if err != nil {
 		return common.Hash{}, common.Hash{}, err
 	}
+	log.Info("end statedb commit")
 	// get the storage root of the L2ToL1MessagePasser contract
 	var storageRootMessagePasser common.Hash
 	if isIsthmus {
@@ -223,9 +225,11 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database, isIsthmus bool)
 	}
 	// Commit newly generated states into disk if it's not empty.
 	if root != types.EmptyRootHash {
+		log.Info("before triedb commit")
 		if err := triedb.Commit(root, true); err != nil {
 			return common.Hash{}, common.Hash{}, err
 		}
+		log.Info("end statedb commit")
 	}
 	return root, storageRootMessagePasser, nil
 }
@@ -683,9 +687,10 @@ func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Has
 // Commit writes the block and state of a genesis specification to the database.
 // The block is committed as the canonical head block.
 func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Block, error) {
-	// if g.Number != 0 {
-	// 	return nil, errors.New("can't commit genesis block with number > 0")
-	// }
+	log.Info("Start Committing genesis")
+	if g.Number != 0 {
+		return nil, errors.New("can't commit genesis block with number > 0")
+	}
 	config := g.Config
 	if config == nil {
 		return nil, errors.New("invalid genesis without chain config")
@@ -706,35 +711,106 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 		}
 	} else {
 		// flush the data to disk and compute the state root
+		log.Info("begin flushAlloc")
 		stateRoot, storageRootMessagePasser, err = flushAlloc(&g.Alloc, triedb, g.Config.IsIsthmus(g.Timestamp))
+		log.Info("end flushAlloc")
 		if err != nil {
 			return nil, err
 		}
 	}
+	log.Info("start toBlockWithRoot")
 	block := g.toBlockWithRoot(stateRoot, storageRootMessagePasser)
-
-	// Marshal the genesis state specification and persist.
+	log.Info("end toBlockWithRoot")
+	//Marshal the genesis state specification and persist.
 	blob, err := json.Marshal(g.Alloc)
 	if err != nil {
+		log.Error("marshaling allocation error", "err", err)
 		return nil, err
 	}
-	batch := db.NewBatch()
-	rawdb.WriteGenesisStateSpec(batch, block.Hash(), blob)
-	rawdb.WriteBlock(batch, block)
-	rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), nil)
-	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(batch, block.Hash())
-	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
-	rawdb.WriteHeadHeaderHash(batch, block.Hash())
-	rawdb.WriteChainConfig(batch, block.Hash(), config)
 
-	if block.NumberU64() != 0 {
-		// Also write the genesis block as number 0
-		rawdb.WriteCanonicalHash(batch, block.Hash(), 0)
-		rawdb.WriteGenesisHeader(batch, block.Header())
+	// Write genesis state spec in its own batch
+	batch1 := db.NewBatch()
+
+	//rawdb.WriteGenesisStateSpec(batch1, block.Hash(), blob)
+	zeroHash := common.Hash{}
+	log.Info("start WriteGenesisStateSpec")
+	rawdb.WriteGenesisStateSpec(batch1, zeroHash, blob)
+
+	if err := batch1.Write(); err != nil {
+		log.Error("write genesis state failed", "err", err)
+		return nil, err
+	}
+	log.Info("end WriteGenesisStateSpec", "size", batch1.ValueSize())
+
+	// Write block in its own batch
+	batch2 := db.NewBatch()
+	rawdb.WriteBlock(batch2, block)
+	log.Info("WriteBlock", "size", batch2.ValueSize())
+	if err := batch2.Write(); err != nil {
+		return nil, err
 	}
 
-	return block, batch.Write()
+	// Write receipts in its own batch
+	batch3 := db.NewBatch()
+	rawdb.WriteReceipts(batch3, block.Hash(), block.NumberU64(), nil)
+	log.Info("WriteReceipts", "size", batch3.ValueSize())
+	if err := batch3.Write(); err != nil {
+		return nil, err
+	}
+
+	// Write canonical hash in its own batch
+	batch4 := db.NewBatch()
+	rawdb.WriteCanonicalHash(batch4, block.Hash(), block.NumberU64())
+	log.Info("WriteCanonicalHash", "size", batch4.ValueSize())
+	if err := batch4.Write(); err != nil {
+		return nil, err
+	}
+
+	// Write head block hash in its own batch
+	batch5 := db.NewBatch()
+	rawdb.WriteHeadBlockHash(batch5, block.Hash())
+	log.Info("WriteHeadBlockHash", "size", batch5.ValueSize())
+	if err := batch5.Write(); err != nil {
+		return nil, err
+	}
+
+	// Write head fast block hash in its own batch
+	batch6 := db.NewBatch()
+	rawdb.WriteHeadFastBlockHash(batch6, block.Hash())
+	log.Info("WriteHeadFastBlockHash", "size", batch6.ValueSize())
+	if err := batch6.Write(); err != nil {
+		return nil, err
+	}
+
+	// Write head header hash in its own batch
+	batch7 := db.NewBatch()
+	rawdb.WriteHeadHeaderHash(batch7, block.Hash())
+	log.Info("WriteHeadHeaderHash", "size", batch7.ValueSize())
+	if err := batch7.Write(); err != nil {
+		return nil, err
+	}
+
+	// Write chain config in its own batch
+	batch8 := db.NewBatch()
+	rawdb.WriteChainConfig(batch8, block.Hash(), config)
+	log.Info("WriteChainConfig", "size", batch8.ValueSize())
+	if err := batch8.Write(); err != nil {
+		return nil, err
+	}
+
+	if block.NumberU64() != 0 {
+		// Also write the genesis block as number 0 in its own batch
+		batch9 := db.NewBatch()
+		rawdb.WriteCanonicalHash(batch9, block.Hash(), 0)
+		rawdb.WriteGenesisHeader(batch9, block.Header())
+		if err := batch9.Write(); err != nil {
+			return nil, err
+		}
+	}
+
+	log.Info("completed all batch writes")
+
+	return block, nil
 }
 
 // MustCommit writes the genesis block and state to db, panicking on error.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -519,10 +519,12 @@ func ReadBody(db ethdb.Reader, hash common.Hash, number uint64) *types.Body {
 
 // WriteBody stores a block body into the database.
 func WriteBody(db ethdb.KeyValueWriter, hash common.Hash, number uint64, body *types.Body) {
+	log.Info("start EncodeToBytes", "hash", hash, "number", number, "body", body)
 	data, err := rlp.EncodeToBytes(body)
 	if err != nil {
 		log.Crit("Failed to RLP encode body", "err", err)
 	}
+	log.Info("start WriteBodyRLP", "hash", hash, "number", number, "body", body)
 	WriteBodyRLP(db, hash, number, data)
 }
 

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -84,18 +84,104 @@ func WriteChainConfig(db ethdb.KeyValueWriter, hash common.Hash, cfg *params.Cha
 	}
 }
 
-// ReadGenesisStateSpec retrieves the genesis state specification based on the
-// given genesis (block-)hash.
-func ReadGenesisStateSpec(db ethdb.KeyValueReader, blockhash common.Hash) []byte {
-	data, _ := db.Get(genesisStateSpecKey(blockhash))
-	return data
-}
+const (
+	maxChunkSize = 4 * 1024 * 1024 // 4MB
+	chunkPrefix  = 0x00            // Special prefix indicating chunked data
+)
 
 // WriteGenesisStateSpec writes the genesis state specification into the disk.
+// If the data is larger than 4KB, it will be split into chunks.
 func WriteGenesisStateSpec(db ethdb.KeyValueWriter, blockhash common.Hash, data []byte) {
-	if err := db.Put(genesisStateSpecKey(blockhash), data); err != nil {
-		log.Crit("Failed to store genesis state", "err", err)
+	key := genesisStateSpecKey(blockhash)
+
+	if len(data) <= maxChunkSize {
+		// Data is small enough, write directly
+		if err := db.Put(key, data); err != nil {
+			log.Crit("Failed to store genesis state", "err", err, "size", len(data))
+		}
+		log.Info("Genesis state written directly", "size", len(data))
+		return
 	}
+
+	// Data is too large, split into chunks
+	numChunks := (len(data) + maxChunkSize - 1) / maxChunkSize // Ceiling division
+
+	if numChunks > 65535 { // (1<<16) - 1
+		log.Crit("Genesis state too large for chunking", "size", len(data), "max_chunks", 255)
+	}
+
+	// Write the special header indicating chunked data
+	header := []byte{chunkPrefix, byte(numChunks)}
+	if err := db.Put(key, header); err != nil {
+		log.Crit("Failed to store genesis state header", "err", err, "chunks", numChunks)
+	}
+
+	// Write each chunk
+	for i := 0; i < numChunks; i++ {
+		start := i * maxChunkSize
+		end := start + maxChunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+
+		chunkKey := append(key, byte(i)) // Append chunk index to original key
+		chunk := data[start:end]
+
+		if err := db.Put(chunkKey, chunk); err != nil {
+			log.Crit("Failed to store genesis state chunk", "err", err, "chunk", i, "size", len(chunk))
+		}
+	}
+
+	log.Info("Genesis state written in chunks", "total_size", len(data), "chunks", numChunks, "chunk_size", maxChunkSize)
+}
+
+// ReadGenesisStateSpec retrieves the genesis state specification based on the
+// given genesis (block-)hash. Handles both direct and chunked data.
+func ReadGenesisStateSpec(db ethdb.KeyValueReader, blockhash common.Hash) []byte {
+	key := genesisStateSpecKey(blockhash)
+	data, _ := db.Get(key)
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	// Check if this is chunked data
+	if len(data) == 2 && data[0] == chunkPrefix {
+		numChunks := int(data[1])
+
+		if numChunks == 0 || numChunks > 65535 {
+			log.Error("Invalid chunk count in genesis state header", "chunks", numChunks)
+			return nil
+		}
+
+		// Read all chunks
+		var chunks [][]byte
+		totalSize := 0
+
+		for i := 0; i < numChunks; i++ {
+			chunkKey := append(key, byte(i))
+			chunk, _ := db.Get(chunkKey)
+			if len(chunk) == 0 {
+				log.Error("Missing genesis state chunk", "chunk", i, "total_chunks", numChunks)
+				return nil
+			}
+			chunks = append(chunks, chunk)
+			totalSize += len(chunk)
+		}
+
+		// Combine all chunks
+		result := make([]byte, 0, totalSize)
+		for _, chunk := range chunks {
+			result = append(result, chunk...)
+		}
+
+		log.Info("Genesis state read from chunks", "total_size", totalSize, "chunks", numChunks)
+		return result
+	}
+
+	// Direct data (not chunked)
+	log.Info("Genesis state read directly", "size", len(data))
+	return data
 }
 
 // crashList is a list of unclean-shutdown-markers, for rlp-encoding to the

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -96,7 +96,10 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 			handles = minHandles
 		}
 		// Set default options
+		options.BlockSize = 1 * opt.MiB
+
 		options.OpenFilesCacheCapacity = handles
+		cache = 1024 // 1GB
 		options.BlockCacheCapacity = cache / 2 * opt.MiB
 		options.WriteBuffer = cache / 4 * opt.MiB // Two of these are used internally
 		if readonly {

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -109,8 +109,10 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 		log.Crit("Both 'hash' and 'path' mode are configured")
 	}
 	if config.PathDB != nil {
+		log.Info("new pathdb")
 		db.backend = pathdb.New(diskdb, config.PathDB, config.IsVerkle)
 	} else {
+		log.Info("new hashdb")
 		db.backend = hashdb.New(diskdb, config.HashDB)
 	}
 	return db

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -129,6 +129,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 		config = Defaults
 	}
 	var cleans *fastcache.Cache
+	log.Info("clean cache size", "config.CleanCacheSize", config.CleanCacheSize)
 	if config.CleanCacheSize > 0 {
 		cleans = fastcache.New(config.CleanCacheSize)
 	}


### PR DESCRIPTION
- Run in ramdisk can remove disk io of levelDB compaction
- Currently, there is issue in writing genesis.json file to levelDB; the fix is to making the genesis write in levelDB in multiple chunks
- Changed levelDB block size and write butter to a bigger value, allowing more efficient write