### PR TITLE
feat: add test-coverage make target for test code coverage check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,21 @@ help: Makefile
 	@echo ''
 	@echo 'Targets:'
 	@sed -n 's/^#?//p' $< | column -t -s ':' |  sort | sed -e 's/^/ /'
+
+test-coverage:
+	@if [ "$(word 2,$(MAKECMDGOALS))" = "" ]; then \
+		echo "Usage: make test-coverage <directory>"; \
+		echo "Example: make test-coverage ./miner"; \
+		echo "         make test-coverage ./..."; \
+		exit 1; \
+	fi
+	@PKG=$(word 2,$(MAKECMDGOALS)); \
+	if echo "$$PKG" | grep -q "^\./" ; then \
+		go test -coverprofile=coverage.out $$PKG; \
+	else \
+		go test -coverprofile=coverage.out ./$$PKG; \
+	fi
+	go tool cover -html=coverage.out -o coverage.html
+	open coverage.html  # macOS
+	sleep 0.5
+	rm coverage.out coverage.html


### PR DESCRIPTION
# Summary

Add a flexible `test-coverage` Makefile target that generates and displays test coverage reports for any Go package directory with automatic cleanup and browser integration. 

This is useful especially when we add customised X Layer functions, and we need to check that our added code are covered sufficiently by tests.

- Supports both relative path formats: E.g. `./miner` and `miner` 
- Generate HTML coverage reports with automatic browser opening
- Automatic cleanup of temporary files

# Features

## Automated Workflow
1. **Generate coverage**: Runs `go test -coverprofile=coverage.out`
2. **Create HTML report**: Uses `go tool cover -html` for visual output  
3. **Open in browser**: Automatically opens coverage.html (macOS)
4. **Clean up**: Removes temporary files after usage

## Usage Examples

### Commands
```bash
# Show help
make test-coverage

# Test specific packages
make test-coverage ./miner
make test-coverage miner  
make test-coverage ./common

# Test all packages
make test-coverage ./...
```

### Coverage report

<img width="1108" height="914" alt="image" src="https://github.com/user-attachments/assets/ddb27f32-e347-4c1d-a16c-d66d7149e2a1" />


**Note**: The test files should be named as `*_test.go` and be placed in the same directory as the code to be tested.
