### PR TITLE
fix(migration): Fix clear account balance to 0 bug & link failed bug(valid reference to runtime.lastmoduledatap)

### DIFF
--- a/core/migration.go
+++ b/core/migration.go
@@ -19,7 +19,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/bytedance/gopkg/util/logger"
 	"math/big"
 	"os"
 	"runtime"
@@ -28,6 +27,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bytedance/gopkg/util/logger"
 
 	"github.com/bytedance/sonic"
 	"github.com/ethereum/go-ethereum/common"
@@ -765,6 +766,7 @@ func verifySMT(chainDataPath string, smtDataPath string, dbAlloc *types.GenesisA
 	log.Info("verifySMT called", "chainDataPath", chainDataPath, "smtDataPath", smtDataPath, "accounts", len(*dbAlloc))
 	smtBatchRootHashOrigin, err := getSmtBatchRootHashOrigin(chainDataPath, smtDataPath)
 	if err != nil {
+		log.Error("getSmtBatchRootHashOrigin failed", "error", err)
 		return err
 	}
 	log.Info("getSmtBatchRootHashOrigin", "smtBatchRootHashOrigin", fmt.Sprintf("0x%s", smtBatchRootHashOrigin.Text(16)))
@@ -772,6 +774,7 @@ func verifySMT(chainDataPath string, smtDataPath string, dbAlloc *types.GenesisA
 	// Use dbAlloc directly for SMT verification
 	smtBatchRootHashRebuild, err := calcSmtRoot(*dbAlloc)
 	if err != nil {
+		log.Error("calcSmtRoot failed", "error", err)
 		return err
 	}
 	log.Info("verifySMT", "smtBatchRootHashOrigin", fmt.Sprintf("0x%s", smtBatchRootHashOrigin.Text(16)), "smtBatchRootHashRebuild", fmt.Sprintf("0x%s", smtBatchRootHashRebuild.Text(16)))

--- a/core/migration.go
+++ b/core/migration.go
@@ -240,7 +240,7 @@ func generateMigrateAlloc(dbAlloc types.GenesisAlloc, ignoreAddresses map[common
 			log.Info("skip migrate for", "addr", addr)
 		}
 	}
-	log.Info("generateMigrateAlloc remove ignored addresses elapsed:", "elapsed", time.Since(start))
+	log.Info("generateMigrateAlloc remove ignored addresses", "elapsed", time.Since(start))
 
 	start = time.Now()
 	// Merge with genesisAlloc and handle conflicts
@@ -259,7 +259,7 @@ func generateMigrateAlloc(dbAlloc types.GenesisAlloc, ignoreAddresses map[common
 
 		migrateAlloc[addr] = destAccount
 	}
-	log.Info("generateMigrateAlloc merge with genesisAlloc elapsed:", "elapsed", time.Since(start))
+	log.Info("generateMigrateAlloc merge with genesisAlloc", "elapsed", time.Since(start))
 
 	return migrateAlloc
 }
@@ -697,7 +697,7 @@ func calcSmtRoot(alloc types.GenesisAlloc) (*big.Int, error) {
 	}
 
 	wg.Wait()
-	log.Info("prepare elapsed:", "elapsed", time.Since(start1))
+	log.Info("prepare finish", "elapsed", time.Since(start1))
 
 	start11 := time.Now()
 	slices.SortFunc(nodeKvs, func(a, b *NodeKV) int {
@@ -712,11 +712,11 @@ func calcSmtRoot(alloc types.GenesisAlloc) (*big.Int, error) {
 		}
 		return 0
 	})
-	log.Info("sorting nodes elapsed:", "elapsed", time.Since(start11))
+	log.Info("sorting nodes finish", "elapsed", time.Since(start11))
 
 	start2 := time.Now()
 	calculateLevels(nodeKvs, 0)
-	log.Info("calculate level elapsed:", "elapsed", time.Since(start2))
+	log.Info("calculate level finish", "elapsed", time.Since(start2))
 
 	start3 := time.Now()
 	// 2. Calculate leaf node hashes concurrently
@@ -751,11 +751,11 @@ func calcSmtRoot(alloc types.GenesisAlloc) (*big.Int, error) {
 		}(i, end)
 	}
 	wg.Wait()
-	log.Info("calculate leaf hash elapsed:", "elapsed", time.Since(start3))
+	log.Info("calculate leaf hash finish", "elapsed", time.Since(start3))
 
 	start4 := time.Now()
 	root := NodeKey(calculateRoot(nodeKvs, 0, len(nodeKvs), 0))
-	log.Info("calculate root hash elapsed:", "elapsed", time.Since(start4))
+	log.Info("calculate root hash finish", "elapsed", time.Since(start4))
 
 	return root.ToBigInt(), nil
 }
@@ -767,14 +767,14 @@ func verifySMT(chainDataPath string, smtDataPath string, dbAlloc *types.GenesisA
 	if err != nil {
 		return err
 	}
-	log.Info("getSmtBatchRootHashOrigin", "smtBatchRootHashOrigin", smtBatchRootHashOrigin)
+	log.Info("getSmtBatchRootHashOrigin", "smtBatchRootHashOrigin", fmt.Sprintf("0x%s", smtBatchRootHashOrigin.Text(16)))
 
 	// Use dbAlloc directly for SMT verification
 	smtBatchRootHashRebuild, err := calcSmtRoot(*dbAlloc)
 	if err != nil {
 		return err
 	}
-	log.Info("verifySMT", "smtBatchRootHashOrigin", smtBatchRootHashOrigin, "smtBatchRootHashRebuild", smtBatchRootHashRebuild)
+	log.Info("verifySMT", "smtBatchRootHashOrigin", fmt.Sprintf("0x%s", smtBatchRootHashOrigin.Text(16)), "smtBatchRootHashRebuild", fmt.Sprintf("0x%s", smtBatchRootHashRebuild.Text(16)))
 
 	if smtBatchRootHashOrigin != nil {
 		if smtBatchRootHashOrigin.Text(16) == smtBatchRootHashRebuild.Text(16) {
@@ -787,6 +787,8 @@ func verifySMT(chainDataPath string, smtDataPath string, dbAlloc *types.GenesisA
 }
 
 func dumpGenesis(genesis *Genesis, outputPath string) {
+	start := time.Now()
+	log.Info("dumpGenesis start")
 	buf, err := sonic.MarshalIndent(genesis, "", "  ")
 	if err != nil {
 		log.Warn("Failed to marshal updated genesis", "error", err)
@@ -796,9 +798,8 @@ func dumpGenesis(genesis *Genesis, outputPath string) {
 		} else {
 			log.Info("Updated genesis written to file", "path", outputPath)
 		}
-	} else {
-		log.Info("Updated genesis not written to file, use --output-path to specify the output path")
 	}
+	log.Info("dumpGenesis finish", "elapsed", time.Since(start))
 }
 
 // SetupGenesisBlockWithMigrationData sets up the genesis block with migration data

--- a/core/smt_utils.go
+++ b/core/smt_utils.go
@@ -18,16 +18,12 @@ package core
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
-	"math"
 	"math/big"
-	"math/bits"
 	"strconv"
 	"strings"
 	"unsafe"
 
-	"github.com/ethereum/go-ethereum/common"
 	poseidon "github.com/okx/poseidongold/go"
 )
 
@@ -48,17 +44,7 @@ type NodeKey [4]uint64
 
 type NodeType int
 
-const (
-	LeafNode   NodeType = iota // 0 for leaf node
-	BranchNode                 // 1 for branch node
-)
-
 type Side int
-
-const (
-	Left  Side = iota // 0 for left
-	Right             // 1 for right
-)
 
 var (
 	LeafCapacity   = [4]uint64{1, 0, 0, 0}
@@ -213,58 +199,6 @@ func NodeKeyFromBigIntArray(arr []*big.Int) NodeKey {
 	return nk
 }
 
-func IsArrayUint64Empty(arr []uint64) bool {
-	for _, v := range arr {
-		if v > 0 {
-			return false
-		}
-	}
-
-	return true
-}
-
-func Value8FromBigIntArray(arr []*big.Int) NodeValue8 {
-	nv := [8]*big.Int{}
-	copy(nv[:], arr)
-	return nv
-}
-
-func NodeValue12FromBigIntArray(arr []*big.Int) (*NodeValue12, error) {
-	if len(arr) != 12 {
-		return &NodeValue12{}, fmt.Errorf("invalid array length")
-	}
-	nv := NodeValue12{}
-	copy(nv[:], arr)
-	return &nv, nil
-}
-
-func NodeValue8FromBigInt(value *big.Int) (*NodeValue8, error) {
-	x := ScalarToArrayBig(value)
-	return NodeValue8FromBigIntArray(x)
-}
-
-func NodeValue8ToBigInt(value *NodeValue8) *big.Int {
-	x := BigIntArrayFromNodeValue8(value)
-	return ArrayBigToScalar(x)
-}
-
-func NodeValue8FromBigIntArray(arr []*big.Int) (*NodeValue8, error) {
-	if len(arr) != 8 {
-		return &NodeValue8{}, fmt.Errorf("invalid array length")
-	}
-	nv := NodeValue8{}
-	copy(nv[:], arr)
-	return &nv, nil
-}
-
-func BigIntArrayFromNodeValue8(nv *NodeValue8) []*big.Int {
-	arr := make([]*big.Int, 8)
-
-	copy(arr, nv[:])
-
-	return arr
-}
-
 func (nv *NodeValue12) IsZero() bool {
 	zero := false
 	for _, v := range nv {
@@ -283,21 +217,6 @@ func (nv *NodeValue12) IsFinalNode() bool {
 		return false
 	}
 	return nv[8].Cmp(big.NewInt(1)) == 0
-}
-
-// 7 times more efficient than sprintf
-func ConvertBigIntToHex(n *big.Int) string {
-	i := int(float64(n.BitLen())/4) + 1
-	if n.Sign() < 0 {
-		i++
-	}
-
-	buf := make([]byte, 2, i+2)
-	buf[0] = '0'
-	buf[1] = 'x'
-
-	buf = n.Append(buf, 16)
-	return unsafe.String(&buf[0], len(buf))
 }
 
 // For X Layer, optimize the conversion
@@ -345,20 +264,14 @@ func ScalarToArrayUint64(scalar *big.Int) [8]uint64 {
 		return result
 	}
 
-	// crate a new big.Int
-	tmp := new(big.Int).Set(scalar)
+	scalarCopy := new(big.Int).Set(scalar)
 
 	for i := 0; i < 8; i++ {
-		result[i] = tmp.Uint64() & 0xFFFFFFFF
-		tmp.Rsh(tmp, 32)
+		result[i] = scalarCopy.Uint64() & 0xFFFFFFFF
+		scalarCopy.Rsh(scalarCopy, 32)
 	}
 
 	return result
-}
-
-func ConvertHexToAddress(hex string) common.Address {
-	bigInt := ConvertHexToBigInt(hex)
-	return common.BigToAddress(bigInt)
 }
 
 func ArrayToScalar(array []uint64) *big.Int {
@@ -379,25 +292,6 @@ func ArrayToScalar(array []uint64) *big.Int {
 	}
 }
 
-func ScalarToArray(scalar *big.Int) []uint64 {
-	scalarCopy := new(big.Int).Set(scalar)
-	mask := new(big.Int)
-	mask.SetString("FFFFFFFFFFFFFFFF", 16)
-
-	r0 := new(big.Int).And(scalarCopy, mask)
-
-	r1 := new(big.Int).Rsh(scalarCopy, 64)
-	r1 = new(big.Int).And(r1, mask)
-
-	r2 := new(big.Int).Rsh(scalarCopy, 128)
-	r2 = new(big.Int).And(r2, mask)
-
-	r3 := new(big.Int).Rsh(scalarCopy, 192)
-	r3 = new(big.Int).And(r3, mask)
-
-	return []uint64{r0.Uint64(), r1.Uint64(), r2.Uint64(), r3.Uint64()}
-}
-
 func ArrayToScalarBig(array []*big.Int) *big.Int {
 	// For X Layer, optimize the conversion
 	// fast path for 64-bit systems
@@ -406,95 +300,6 @@ func ArrayToScalarBig(array []*big.Int) *big.Int {
 		return v
 	}
 	return arrayToScalarBigSlow(array)
-}
-
-func ScalarToNodeKey(s *big.Int) NodeKey {
-	auxk := make([]*big.Int, 4)
-	for i := range auxk {
-		auxk[i] = big.NewInt(0)
-	}
-
-	r := new(big.Int).Set(s)
-	i := big.NewInt(0)
-	one := big.NewInt(1)
-
-	for r.BitLen() > 0 {
-		if new(big.Int).And(r, one).BitLen() > 0 {
-			auxk[new(big.Int).Mod(i, big.NewInt(4)).Int64()] = new(big.Int).Add(
-				auxk[new(big.Int).Mod(i, big.NewInt(4)).Int64()],
-				new(big.Int).Lsh(one, uint(new(big.Int).Div(i, big.NewInt(4)).Uint64())),
-			)
-		}
-		r = r.Rsh(r, 1)
-		i.Add(i, one)
-	}
-
-	return NodeKey{
-		auxk[0].Uint64(),
-		auxk[1].Uint64(),
-		auxk[2].Uint64(),
-		auxk[3].Uint64(),
-	}
-}
-
-func ScalarToRoot(s *big.Int) NodeKey {
-	// For X Layer, optimize the conversion
-	if s.Sign() < 0 {
-		return scalarToRootSlow(s)
-	}
-	var result [4]uint64
-
-	if bits.UintSize == 64 {
-		sbits := s.Bits()
-		for i := 0; i < 4; i++ {
-			if i < len(sbits) {
-				result[i] = uint64(sbits[i])
-			}
-		}
-	} else {
-		// 2**64
-		//var divisor *big.Int
-		//if bits.UintSize == 64 {
-		//	divisor = new(big.Int).SetBits([]big.Word{0, 1})
-		//} else {
-		//	divisor = new(big.Int).SetBits([]big.Word{0, 0, 1})
-		//}
-		// divisor := new(big.Int).Exp(big.NewInt(2), big.NewInt(64), nil)
-
-		sCopy := new(big.Int).Set(s)
-
-		for i := 0; i < 4; i++ {
-			// For X Layer, optimize the conversion
-			//mod := new(big.Int).Mod(sCopy, divisor)
-			result[i] = sCopy.Uint64()
-			// sCopy.Div(sCopy, divisor)
-			sCopy.Rsh(sCopy, 64)
-		}
-	}
-	return result
-}
-
-func ScalarToNodeValue(scalarIn *big.Int) NodeValue12 {
-	out := [12]*big.Int{}
-	// For X Layer, optimize the conversion
-	if ok := scalarToNodeValueFast(scalarIn, &out); ok {
-		return out
-	}
-
-	return scalarToNodeValueSlow(scalarIn)
-}
-
-func ScalarToNodeValue8(scalarIn *big.Int) NodeValue8 {
-	out := [8]*big.Int{}
-	mask := new(big.Int).SetBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
-	scalar := new(big.Int).Set(scalarIn)
-
-	for i := 0; i < 8; i++ {
-		value := new(big.Int).And(scalar, mask)
-		out[i] = value
-		scalar.Rsh(scalar, 64)
-	}
-	return out
 }
 
 func (nk *NodeKey) GetPath() []int {
@@ -511,62 +316,6 @@ func (nk *NodeKey) GetPath() []int {
 	return res
 }
 
-func NodeKeyFromPath(path []int) (NodeKey, error) {
-	if len(path) != 256 {
-		return NodeKey{}, fmt.Errorf("path is not 256 bits")
-	}
-
-	res := [4]uint64{0, 0, 0, 0}
-
-	for j := 0; j < 256; j++ {
-		i := j % 4
-
-		k := j / 4
-		res[i] |= uint64(path[j]) << k
-	}
-
-	return res, nil
-}
-
-func BinaryKey(key NodeKey) string {
-	return fmt.Sprintf("%064b%064b%064b%064b", key[0], key[1], key[2], key[3])
-}
-
-func ConcatArrays4(a, b [4]uint64) [8]uint64 {
-	result := [8]uint64{}
-
-	copy(result[:], a[:])
-
-	for i, v := range b {
-		result[i+4] = v
-	}
-	return result
-}
-
-func ConcatArrays4ByPointers(a, b *[4]uint64) *[8]uint64 {
-	return &[8]uint64{
-		a[0], a[1], a[2], a[3],
-		b[0], b[1], b[2], b[3],
-	}
-}
-
-func ConcatArrays8AndCapacityByPointers(in *[8]uint64, capacity *[4]uint64) *NodeValue12 {
-	v := NodeValue12{}
-	for i, val := range in {
-		v[i] = new(big.Int).SetUint64(val)
-	}
-	for i, val := range capacity {
-		v[i+8] = new(big.Int).SetUint64(val)
-	}
-
-	return &v
-}
-
-func HashKeyAndValueByPointers(in *[8]uint64, capacity *[4]uint64) (*[4]uint64, *NodeValue12) {
-	h := HashByPointers(in, capacity)
-	return h, ConcatArrays8AndCapacityByPointers(in, capacity)
-}
-
 func RemoveKeyBits(k NodeKey, nBits int) NodeKey {
 	var auxk NodeKey
 	fullLevels := nBits / 4
@@ -580,139 +329,6 @@ func RemoveKeyBits(k NodeKey, nBits int) NodeKey {
 	}
 
 	return auxk
-}
-
-func ScalarToArrayBig12(scalar *big.Int) []*big.Int {
-	scalarCopy := new(big.Int).Set(scalar)
-	mask := new(big.Int)
-	mask.SetString("FFFFFFFF", 16)
-
-	r0 := new(big.Int).And(scalarCopy, mask)
-
-	r1 := new(big.Int).Rsh(scalarCopy, 32)
-	r1 = new(big.Int).And(r1, mask)
-
-	r2 := new(big.Int).Rsh(scalarCopy, 64)
-	r2 = new(big.Int).And(r2, mask)
-
-	r3 := new(big.Int).Rsh(scalarCopy, 96)
-	r3 = new(big.Int).And(r3, mask)
-
-	r4 := new(big.Int).Rsh(scalarCopy, 128)
-	r4 = new(big.Int).And(r4, mask)
-
-	r5 := new(big.Int).Rsh(scalarCopy, 160)
-	r5 = new(big.Int).And(r5, mask)
-
-	r6 := new(big.Int).Rsh(scalarCopy, 192)
-	r6 = new(big.Int).And(r6, mask)
-
-	r7 := new(big.Int).Rsh(scalarCopy, 224)
-	r7 = new(big.Int).And(r7, mask)
-
-	r8 := new(big.Int).Rsh(scalarCopy, 256)
-	r8 = new(big.Int).And(r8, mask)
-
-	r9 := new(big.Int).Rsh(scalarCopy, 288)
-	r9 = new(big.Int).And(r9, mask)
-
-	r10 := new(big.Int).Rsh(scalarCopy, 320)
-	r10 = new(big.Int).And(r10, mask)
-
-	r11 := new(big.Int).Rsh(scalarCopy, 352)
-	r11 = new(big.Int).And(r11, mask)
-
-	return []*big.Int{r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11}
-}
-
-var mask = big.NewInt(4294967295)
-
-func ScalarToArrayBig(scalar *big.Int) []*big.Int {
-	scalarCopy := new(big.Int).Set(scalar)
-	r0 := new(big.Int).And(scalarCopy, mask)
-
-	r1 := new(big.Int).Rsh(scalarCopy, 32)
-	r1.And(r1, mask)
-
-	r2 := new(big.Int).Rsh(scalarCopy, 64)
-	r2.And(r2, mask)
-
-	r3 := new(big.Int).Rsh(scalarCopy, 96)
-	r3.And(r3, mask)
-
-	r4 := new(big.Int).Rsh(scalarCopy, 128)
-	r4.And(r4, mask)
-
-	r5 := new(big.Int).Rsh(scalarCopy, 160)
-	r5.And(r5, mask)
-
-	r6 := new(big.Int).Rsh(scalarCopy, 192)
-	r6.And(r6, mask)
-
-	r7 := new(big.Int).Rsh(scalarCopy, 224)
-	r7.And(r7, mask)
-
-	return []*big.Int{r0, r1, r2, r3, r4, r5, r6, r7}
-}
-
-func ArrayBigToScalar(arr []*big.Int) *big.Int {
-	scalar := new(big.Int)
-	for i := len(arr) - 1; i >= 0; i-- {
-		scalar.Lsh(scalar, 32)
-		scalar.Add(scalar, arr[i])
-	}
-	return scalar
-}
-
-func JoinKey(usedBits []int, remainingKey NodeKey) *NodeKey {
-	n := make([]uint64, 4)
-	accs := make([]uint64, 4)
-
-	for i := 0; i < len(usedBits); i++ {
-		if usedBits[i] == 1 {
-			accs[i%4] = accs[i%4] | (1 << n[i%4])
-		}
-		n[i%4]++
-	}
-
-	auxk := make([]uint64, 4)
-	for i := 0; i < 4; i++ {
-		auxk[i] = remainingKey[i]<<n[i] | accs[i]
-	}
-
-	return &NodeKey{auxk[0], auxk[1], auxk[2], auxk[3]}
-}
-
-func RemoveOver(m map[int]*NodeValue12, level int) map[int]*NodeValue12 {
-	result := make(map[int]*NodeValue12)
-	for k, v := range m {
-		if k < level {
-			result[k] = v
-		}
-	}
-	return result
-}
-
-func StringToH4(s string) ([4]uint64, error) {
-	if !strings.HasPrefix(s, "0x") {
-		return [4]uint64{}, errors.New("hexadecimal required")
-	}
-
-	if len(s) != 66 {
-		return [4]uint64{}, errors.New("hexadecimal all digits required")
-	}
-
-	var res [4]uint64
-	var err error
-
-	for i := 0; i < 4; i++ {
-		res[3-i], err = strconv.ParseUint(s[2+(16*i):18+(16*i)], 16, 64)
-		if err != nil {
-			return [4]uint64{}, fmt.Errorf("failed to convert string to uint64: %v", err)
-		}
-	}
-
-	return res, nil
 }
 
 func KeyEthAddrBalance(ethAddr string) NodeKey {
@@ -740,118 +356,6 @@ func Key(ethAddr string, c int) NodeKey {
 	key1[7] = 0
 
 	return Hash(key1, key1Capacity)
-}
-
-func KeyBig(k *big.Int, c int) (*NodeKey, error) {
-	if k == nil {
-		return nil, errors.New("nil key")
-	}
-	add := ScalarToArrayBig(k)
-
-	key1 := NodeValue8{add[0], add[1], add[2], add[3], add[4], add[5], big.NewInt(int64(c)), big.NewInt(0)}
-	key1Capacity, err := StringToH4(HASH_POSEIDON_ALL_ZEROES)
-	if err != nil {
-		return nil, err
-	}
-
-	hk0 := Hash(key1.ToUintArray(), key1Capacity)
-	return &NodeKey{hk0[0], hk0[1], hk0[2], hk0[3]}, nil
-}
-
-func StrValToBigInt(v string) (*big.Int, bool) {
-	if strings.HasPrefix(v, "0x") {
-		return new(big.Int).SetString(v[2:], 16)
-	}
-
-	return new(big.Int).SetString(v, 10)
-}
-
-func KeyContractStorage(ethAddr []*big.Int, storagePosition string) NodeKey {
-	sp, _ := StrValToBigInt(storagePosition)
-	spArray, err := NodeValue8FromBigIntArray(ScalarToArrayBig(sp))
-	if err != nil {
-		return NodeKey{}
-	}
-
-	spUintArray := spArray.ToUintArray()
-	hk0 := HashByPointers(&spUintArray, &BranchCapacity)
-
-	key1 := NodeValue8{ethAddr[0], ethAddr[1], ethAddr[2], ethAddr[3], ethAddr[4], ethAddr[5], big.NewInt(int64(SC_STORAGE)), big.NewInt(0)}
-
-	return Hash(key1.ToUintArray(), *hk0)
-}
-
-func HashContractBytecode(bc string) string {
-	return ConvertBigIntToHex(HashContractBytecodeBigInt(bc))
-}
-
-func HashContractBytecodeBigIntV1(bc string) *big.Int {
-	bytecode := bc
-
-	if strings.HasPrefix(bc, "0x") {
-		bytecode = bc[2:]
-	}
-
-	if len(bytecode)%2 != 0 {
-		bytecode = "0" + bytecode
-	}
-
-	bytecode += "01"
-
-	for len(bytecode)%(56*2) != 0 {
-		bytecode += "00"
-	}
-
-	lastByteInt, _ := strconv.ParseInt(bytecode[len(bytecode)-2:], 16, 64)
-	lastByte := strconv.FormatInt(lastByteInt|0x80, 16)
-	bytecode = bytecode[:len(bytecode)-2] + lastByte
-
-	numBytes := float64(len(bytecode)) / 2
-	numHashes := int(math.Ceil(numBytes / (BYTECODE_ELEMENTS_HASH * BYTECODE_BYTES_ELEMENT)))
-
-	tmpHash := [4]uint64{0, 0, 0, 0}
-	bytesPointer := 0
-
-	maxBytesToAdd := BYTECODE_ELEMENTS_HASH * BYTECODE_BYTES_ELEMENT
-	var elementsToHash []uint64
-	var in [8]uint64
-	var capacity [4]uint64
-	scalar := new(big.Int)
-	tmpScalar := new(big.Int)
-	var byteToAdd string
-	for i := 0; i < numHashes; i++ {
-		elementsToHash = tmpHash[:]
-
-		subsetBytecode := bytecode[bytesPointer : bytesPointer+maxBytesToAdd*2]
-		bytesPointer += maxBytesToAdd * 2
-
-		tmpElem := ""
-		counter := 0
-
-		for j := 0; j < maxBytesToAdd; j++ {
-			byteToAdd = "00"
-			if j < len(subsetBytecode)/2 {
-				byteToAdd = subsetBytecode[j*2 : (j+1)*2]
-			}
-
-			tmpElem = byteToAdd + tmpElem
-			counter += 1
-
-			if counter == BYTECODE_BYTES_ELEMENT {
-				tmpScalar, _ = scalar.SetString(tmpElem, 16)
-				elementsToHash = append(elementsToHash, tmpScalar.Uint64())
-				tmpElem = ""
-				counter = 0
-			}
-		}
-
-		copy(in[:], elementsToHash[4:12])
-		copy(capacity[:], elementsToHash[:4])
-
-		tmpHash = Hash(in, capacity)
-	}
-
-	return ArrayToScalar(tmpHash[:])
 }
 
 func charToByte(c byte) byte {
@@ -923,56 +427,6 @@ func HashContractBytecodeBigInt(bc string) *big.Int {
 	return ArrayToScalar(tmpHash[:])
 }
 
-func ResizeHashTo32BytesByPrefixingWithZeroes(hashValue []byte) []byte {
-	lenDiff := 32 - len(hashValue)
-	if lenDiff > 0 {
-		result := make([]byte, 32)
-		copy(result[lenDiff:], hashValue)
-		return result
-	}
-
-	return hashValue
-}
-
-func binaryStringToUint64(binary string) (uint64, error) {
-	num, err := strconv.ParseUint(binary, 2, 64)
-	if err != nil {
-		return 0, err
-	}
-	return num, nil
-}
-
-func SortNodeKeysBitwiseAsc(keys []NodeKey) {
-	// This would need a sort implementation, but we'll handle sorting in the main function
-}
-
-func EncodeKeySource(t int, accountAddr common.Address, storagePosition common.Hash) []byte {
-	var keySource []byte
-	keySource = append(keySource, byte(t))
-	keySource = append(keySource, accountAddr.Bytes()...)
-	if t == SC_STORAGE {
-		keySource = append(keySource, storagePosition.Bytes()...)
-	}
-	return keySource
-}
-
-func DecodeKeySource(keySource []byte) (int, common.Address, common.Hash, error) {
-	if len(keySource) < 1+common.AddressLength {
-		return 0, common.Address{}, common.Hash{}, fmt.Errorf("invalid key source length")
-	}
-
-	t := int(keySource[0])
-	accountAddr := common.BytesToAddress(keySource[1 : common.AddressLength+1])
-	var storagePosition common.Hash
-	if t == SC_STORAGE {
-		if len(keySource) < 1+common.AddressLength+common.HashLength {
-			return 0, common.Address{}, common.Hash{}, fmt.Errorf("invalid key source length")
-		}
-		storagePosition = common.BytesToHash(keySource[common.AddressLength+1 : common.AddressLength+common.HashLength+1])
-	}
-	return t, accountAddr, storagePosition, nil
-}
-
 // Helper functions for optimization
 func arrayToScalarBigFast(array []*big.Int) (*big.Int, bool) {
 	// Fast path implementation for 64-bit systems
@@ -1007,46 +461,4 @@ func arrayToScalarBigSlow(array []*big.Int) *big.Int {
 		}
 	}
 	return scalar
-}
-
-func scalarToRootSlow(s *big.Int) NodeKey {
-	// Slow path for negative numbers
-	var result [4]uint64
-	sCopy := new(big.Int).Set(s)
-
-	for i := 0; i < 4; i++ {
-		result[i] = sCopy.Uint64()
-		sCopy.Rsh(sCopy, 64)
-	}
-	return result
-}
-
-func scalarToNodeValueFast(scalarIn *big.Int, out *[12]*big.Int) bool {
-	// Fast path implementation
-	if scalarIn == nil || scalarIn.BitLen() > 384 {
-		return false
-	}
-
-	mask := new(big.Int).SetBytes([]byte{0xff, 0xff, 0xff, 0xff})
-	scalar := new(big.Int).Set(scalarIn)
-
-	for i := 0; i < 12; i++ {
-		value := new(big.Int).And(scalar, mask)
-		out[i] = value
-		scalar.Rsh(scalar, 32)
-	}
-	return true
-}
-
-func scalarToNodeValueSlow(scalarIn *big.Int) NodeValue12 {
-	out := [12]*big.Int{}
-	mask := new(big.Int).SetBytes([]byte{0xff, 0xff, 0xff, 0xff})
-	scalar := new(big.Int).Set(scalarIn)
-
-	for i := 0; i < 12; i++ {
-		value := new(big.Int).And(scalar, mask)
-		out[i] = value
-		scalar.Rsh(scalar, 32)
-	}
-	return out
 }

--- a/core/smt_utils.go
+++ b/core/smt_utils.go
@@ -380,19 +380,19 @@ func ArrayToScalar(array []uint64) *big.Int {
 }
 
 func ScalarToArray(scalar *big.Int) []uint64 {
-	scalar = new(big.Int).Set(scalar)
+	scalarCopy := new(big.Int).Set(scalar)
 	mask := new(big.Int)
 	mask.SetString("FFFFFFFFFFFFFFFF", 16)
 
-	r0 := new(big.Int).And(scalar, mask)
+	r0 := new(big.Int).And(scalarCopy, mask)
 
-	r1 := new(big.Int).Rsh(scalar, 64)
+	r1 := new(big.Int).Rsh(scalarCopy, 64)
 	r1 = new(big.Int).And(r1, mask)
 
-	r2 := new(big.Int).Rsh(scalar, 128)
+	r2 := new(big.Int).Rsh(scalarCopy, 128)
 	r2 = new(big.Int).And(r2, mask)
 
-	r3 := new(big.Int).Rsh(scalar, 192)
+	r3 := new(big.Int).Rsh(scalarCopy, 192)
 	r3 = new(big.Int).And(r3, mask)
 
 	return []uint64{r0.Uint64(), r1.Uint64(), r2.Uint64(), r3.Uint64()}
@@ -583,43 +583,43 @@ func RemoveKeyBits(k NodeKey, nBits int) NodeKey {
 }
 
 func ScalarToArrayBig12(scalar *big.Int) []*big.Int {
-	scalar = new(big.Int).Set(scalar)
+	scalarCopy := new(big.Int).Set(scalar)
 	mask := new(big.Int)
 	mask.SetString("FFFFFFFF", 16)
 
-	r0 := new(big.Int).And(scalar, mask)
+	r0 := new(big.Int).And(scalarCopy, mask)
 
-	r1 := new(big.Int).Rsh(scalar, 32)
+	r1 := new(big.Int).Rsh(scalarCopy, 32)
 	r1 = new(big.Int).And(r1, mask)
 
-	r2 := new(big.Int).Rsh(scalar, 64)
+	r2 := new(big.Int).Rsh(scalarCopy, 64)
 	r2 = new(big.Int).And(r2, mask)
 
-	r3 := new(big.Int).Rsh(scalar, 96)
+	r3 := new(big.Int).Rsh(scalarCopy, 96)
 	r3 = new(big.Int).And(r3, mask)
 
-	r4 := new(big.Int).Rsh(scalar, 128)
+	r4 := new(big.Int).Rsh(scalarCopy, 128)
 	r4 = new(big.Int).And(r4, mask)
 
-	r5 := new(big.Int).Rsh(scalar, 160)
+	r5 := new(big.Int).Rsh(scalarCopy, 160)
 	r5 = new(big.Int).And(r5, mask)
 
-	r6 := new(big.Int).Rsh(scalar, 192)
+	r6 := new(big.Int).Rsh(scalarCopy, 192)
 	r6 = new(big.Int).And(r6, mask)
 
-	r7 := new(big.Int).Rsh(scalar, 224)
+	r7 := new(big.Int).Rsh(scalarCopy, 224)
 	r7 = new(big.Int).And(r7, mask)
 
-	r8 := new(big.Int).Rsh(scalar, 256)
+	r8 := new(big.Int).Rsh(scalarCopy, 256)
 	r8 = new(big.Int).And(r8, mask)
 
-	r9 := new(big.Int).Rsh(scalar, 288)
+	r9 := new(big.Int).Rsh(scalarCopy, 288)
 	r9 = new(big.Int).And(r9, mask)
 
-	r10 := new(big.Int).Rsh(scalar, 320)
+	r10 := new(big.Int).Rsh(scalarCopy, 320)
 	r10 = new(big.Int).And(r10, mask)
 
-	r11 := new(big.Int).Rsh(scalar, 352)
+	r11 := new(big.Int).Rsh(scalarCopy, 352)
 	r11 = new(big.Int).And(r11, mask)
 
 	return []*big.Int{r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11}
@@ -628,27 +628,28 @@ func ScalarToArrayBig12(scalar *big.Int) []*big.Int {
 var mask = big.NewInt(4294967295)
 
 func ScalarToArrayBig(scalar *big.Int) []*big.Int {
-	r0 := new(big.Int).And(scalar, mask)
+	scalarCopy := new(big.Int).Set(scalar)
+	r0 := new(big.Int).And(scalarCopy, mask)
 
-	r1 := new(big.Int).Rsh(scalar, 32)
+	r1 := new(big.Int).Rsh(scalarCopy, 32)
 	r1.And(r1, mask)
 
-	r2 := new(big.Int).Rsh(scalar, 64)
+	r2 := new(big.Int).Rsh(scalarCopy, 64)
 	r2.And(r2, mask)
 
-	r3 := new(big.Int).Rsh(scalar, 96)
+	r3 := new(big.Int).Rsh(scalarCopy, 96)
 	r3.And(r3, mask)
 
-	r4 := new(big.Int).Rsh(scalar, 128)
+	r4 := new(big.Int).Rsh(scalarCopy, 128)
 	r4.And(r4, mask)
 
-	r5 := new(big.Int).Rsh(scalar, 160)
+	r5 := new(big.Int).Rsh(scalarCopy, 160)
 	r5.And(r5, mask)
 
-	r6 := new(big.Int).Rsh(scalar, 192)
+	r6 := new(big.Int).Rsh(scalarCopy, 192)
 	r6.And(r6, mask)
 
-	r7 := new(big.Int).Rsh(scalar, 224)
+	r7 := new(big.Int).Rsh(scalarCopy, 224)
 	r7.And(r7, mask)
 
 	return []*big.Int{r0, r1, r2, r3, r4, r5, r6, r7}
@@ -682,12 +683,14 @@ func JoinKey(usedBits []int, remainingKey NodeKey) *NodeKey {
 	return &NodeKey{auxk[0], auxk[1], auxk[2], auxk[3]}
 }
 
-func RemoveOver(m map[int]*NodeValue12, level int) {
-	for k := range m {
-		if k >= level {
-			delete(m, k)
+func RemoveOver(m map[int]*NodeValue12, level int) map[int]*NodeValue12 {
+	result := make(map[int]*NodeValue12)
+	for k, v := range m {
+		if k < level {
+			result[k] = v
 		}
 	}
+	return result
 }
 
 func StringToH4(s string) ([4]uint64, error) {

--- a/core/smt_utils.go
+++ b/core/smt_utils.go
@@ -345,7 +345,9 @@ func ScalarToArrayUint64(scalar *big.Int) [8]uint64 {
 		return result
 	}
 
-	tmp := scalar
+	// crate a new big.Int
+	tmp := new(big.Int).Set(scalar)
+
 	for i := 0; i < 8; i++ {
 		result[i] = tmp.Uint64() & 0xFFFFFFFF
 		tmp.Rsh(tmp, 32)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum/go-ethereum
 
 go 1.24
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.45
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.43
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.30.2
+	github.com/bytedance/gopkg v0.1.3
 	github.com/bytedance/sonic v1.14.1
 	github.com/cespare/cp v0.1.0
 	github.com/cloudflare/cloudflare-go v0.114.0
@@ -103,7 +104,6 @@ require (
 	github.com/aws/smithy-go v1.15.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
-	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect


### PR DESCRIPTION
This pull request primarily improves logging clarity and error handling within the `core/migration.go` module, and makes minor dependency updates and a small bug fix. The most important changes are grouped below:

**Logging improvements and error handling:**

* Refined log messages in `core/migration.go` to use more descriptive and consistent wording (e.g., replacing "elapsed:" with "finish" and standardizing output formats for hashes). This affects several functions, including `generateMigrateAlloc`, `calcSmtRoot`, and `dumpGenesis`. [[1]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78L243-R244) [[2]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78L262-R263) [[3]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78L700-R701) [[4]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78L715-R720) [[5]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78L754-R759) [[6]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78R769-R780) [[7]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78R793-R794) [[8]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78L799-R805)
* Added error logging for failures in `getSmtBatchRootHashOrigin` and `calcSmtRoot` within the `verifySMT` function.

**Dependency management:**

* Updated Go toolchain version from `go1.24.0` to `go1.24.1` in `go.mod`.
* Promoted `github.com/bytedance/gopkg` from an indirect to a direct dependency in `go.mod`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R16) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L106)

**Bug fix:**

* Fixed a potential mutation bug in `ScalarToArrayUint64` by copying the `big.Int` before modifying it, preventing unintended side effects.

**Code organization:**

* Moved the import of `github.com/bytedance/gopkg/util/logger` to the correct location in the import block for better readability. [[1]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78L22) [[2]](diffhunk://#diff-04e5a16509d95c8add37f44c821f2c816cf6ae3be1711b328ef7ce82218b5e78R31-R32)