### PR TITLE
Fix: Resolve innertxs bugs

### DIFF
--- a/core/state_processor_xlayer.go
+++ b/core/state_processor_xlayer.go
@@ -25,16 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
-func afterApplyTransaction(env *vm.EVM, failed bool) []*types.InnerTx {
-	innerTxs := env.GetInnerTxMeta().InnerTxs
-	if failed {
-		for _, innerTx := range innerTxs {
-			innerTx.IsError = true
-		}
-	}
-	return innerTxs
-}
-
 func ApplyTransactionWithEVM_XLayer(msg *Message, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (receipt *types.Receipt, innerTXs []*types.InnerTx, err error) {
 	if hooks := evm.Config.Tracer; hooks != nil {
 		if hooks.OnTxStart != nil {
@@ -77,4 +67,14 @@ func ApplyTransactionWithEVM_XLayer(msg *Message, gp *GasPool, statedb *state.St
 	}
 
 	return MakeReceipt(evm, result, statedb, blockNumber, blockHash, tx, *usedGas, root, evm.ChainConfig(), nonce), innerTxs, nil
+}
+
+func afterApplyTransaction(env *vm.EVM, failed bool) []*types.InnerTx {
+	innerTxs := env.PopInnerTxs()
+	if failed {
+		for _, innerTx := range innerTxs {
+			innerTx.IsError = true
+		}
+	}
+	return innerTxs
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -471,11 +471,6 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 
 		st.state.RevertToSnapshot(snap)
 
-		// For X Layer
-		// Clear inner transactions for failed deposit transactions
-		// Since the deposit failed, any inner transactions captured should be discarded
-		st.evm.ClearInnerTxs()
-
 		// Even though we revert the state changes, always increment the nonce for the next deposit transaction
 		st.state.SetNonce(st.msg.From, st.state.GetNonce(st.msg.From)+1, tracing.NonceChangeEoACall)
 		// Record deposits as using all their gas (matches the gas pool)

--- a/core/vm/evm_xlayer.go
+++ b/core/vm/evm_xlayer.go
@@ -34,16 +34,18 @@ func (evm *EVM) AddInnerTx(innerTx *types.InnerTx) {
 	evm.innerTxMeta.InnerTxs = append(evm.innerTxMeta.InnerTxs, innerTx)
 }
 
-func (evm *EVM) ClearInnerTxs() {
-	if evm.innerTxMeta != nil {
-		evm.innerTxMeta.InnerTxs = evm.innerTxMeta.InnerTxs[:0] // Clear the slice
-		evm.innerTxMeta.index = 0
-		evm.innerTxMeta.lastDepth = 0
-		// Clear the index map
-		for k := range evm.innerTxMeta.indexMap {
-			delete(evm.innerTxMeta.indexMap, k)
-		}
+func (evm *EVM) PopInnerTxs() []*types.InnerTx {
+	innertxs := make([]*types.InnerTx, len(evm.innerTxMeta.InnerTxs))
+	copy(innertxs, evm.innerTxMeta.InnerTxs)
+
+	evm.innerTxMeta.InnerTxs = evm.innerTxMeta.InnerTxs[:0]
+	evm.innerTxMeta.index = 0
+	evm.innerTxMeta.lastDepth = 0
+	// Clear the index map
+	for k := range evm.innerTxMeta.indexMap {
+		delete(evm.innerTxMeta.indexMap, k)
 	}
+	return innertxs
 }
 
 func beforeOp(


### PR DESCRIPTION
## Summary

- Fix issue where the inner txs map inside the evm instance is flushed incorrectly for failed deposit txs. The deposit txs are still minted on every block which results in nil innertxs for those txs
- Fix issue where innertxs map in the evm instance should now pop all innertxs metadata per tx execution after every tx execution. The evm instance differ from erigon client where the evm instance is re-used per block. We need to flush the map after every execution to ensure innertxs accumulated is correct