### PR TITLE
Miner: Add caching on payload to prevent rebuild on recommits

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -118,6 +118,11 @@ type Payload struct {
 
 	// For X Layer, realtime
 	changeset *realtimeTypes.Changeset
+
+	// For X Layer, incremental building
+	incrementalFlag bool
+	baseEnv         *environment
+	baseParent      common.Hash
 }
 
 // newPayload initializes the payload object.
@@ -134,6 +139,10 @@ func newPayload(lifeCtx context.Context, empty *types.Block, emptyRequests [][]b
 
 		rpcCtx:    rpcCtx,
 		rpcCancel: rpcCancel,
+
+		// For X Layer
+		incrementalFlag: false,
+		baseEnv:         nil,
 	}
 	log.Info("Starting work on payload", "id", payload.id)
 	payload.cond = sync.NewCond(&payload.lock)
@@ -176,6 +185,13 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) {
 		payload.fullWitness = r.witness
 		// For X Layer, realtime
 		payload.changeset = r.changeset
+
+		// For X Layer, cache successful env for incremental updates
+		if r.env != nil {
+			payload.incrementalFlag = true
+			payload.baseEnv = r.env.snapshot()
+			payload.baseParent = r.block.ParentHash()
+		}
 
 		feesInEther := new(big.Float).Quo(new(big.Float).SetInt(r.fees), big.NewFloat(params.Ether))
 		log.Info("Updated payload",
@@ -394,8 +410,18 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 
 		updatePayload := func() time.Duration {
 			start := time.Now()
-			// getSealingBlock is interrupted by shared interrupt
-			r := miner.generateWork(fullParams, witness)
+			var r *newPayloadResult
+			// For X Layer, incremental building
+			if !payload.incrementalFlag {
+				// getSealingBlock is interrupted by shared interrupt
+				r = miner.generateWork(fullParams, witness)
+			} else {
+				incResult, ok := miner.tryIncrementalUpdate(payload, fullParams, witness)
+				if !ok {
+					log.Debug("Incremental update returned with error, rebuilding", "id", payload.id, "err", incResult.err)
+				}
+				r = incResult
+			}
 			dur := time.Since(start)
 			// update handles error case
 			payload.update(r, dur)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -81,6 +81,9 @@ type environment struct {
 
 	noTxs  bool            // true if we are reproducing a block, and do not have to check interop txs
 	rpcCtx context.Context // context to control block-building RPC work. No RPC allowed if nil.
+
+	// For X Layer
+	okPayTxs int
 }
 
 const (
@@ -101,7 +104,8 @@ type newPayloadResult struct {
 	receipts []*types.Receipt       // Receipts collected during construction
 	requests [][]byte               // Consensus layer requests collected during block construction
 	witness  *stateless.Witness     // Witness is an optional stateless proof
-	// For X Layer, realtime
+	// For X Layer
+	env       *environment // Environment snapshot for incremental building
 	changeset *realtimeTypes.Changeset
 }
 
@@ -174,7 +178,7 @@ func (miner *Miner) generateWork(params *generateParams, witness bool) *newPaylo
 			interrupt.Store(commitInterruptTimeout)
 		})
 
-		err := miner.fillTransactions(interrupt, work, params.realtimeEnabled)
+		err := miner.fillTransactions(interrupt, work, nil, params.realtimeEnabled)
 		timer.Stop() // don't need timeout interruption any more
 		if errors.Is(err, errBlockInterruptedByTimeout) {
 			log.Warn("Block building is interrupted", "allowance", common.PrettyDuration(miner.config.Recommit))
@@ -261,7 +265,8 @@ func (miner *Miner) generateWork(params *generateParams, witness bool) *newPaylo
 		receipts: work.receipts,
 		requests: requests,
 		witness:  work.witness,
-		// For X Layer, realtime
+		// For X Layer
+		env:       work,
 		changeset: work.state.GenerateChangeset(),
 	}
 }
@@ -412,6 +417,8 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 		witness:  state.Witness(),
 		evm:      vm.NewEVM(core.NewEVMBlockContext(header, miner.chain, &coinbase, miner.chainConfig, state), state, miner.chainConfig, vm.Config{EnableInnerTxs: miner.backend.RealtimeEnabled()}),
 		rpcCtx:   rpcCtx,
+		// For X Layer
+		okPayTxs: 0,
 	}, nil
 }
 
@@ -687,7 +694,7 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 // fillTransactions retrieves the pending transactions from the txpool and fills them
 // into the given sealing block. The transaction selection and ordering strategy can
 // be customized with the plugin in the future.
-func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment, realtimeEnabled bool) error {
+func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment, existTxs map[common.Hash]struct{}, realtimeEnabled bool) error {
 	miner.confMu.RLock()
 	tip := miner.config.GasPrice
 	prio := miner.prio
@@ -711,6 +718,10 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment, 
 
 	filter.OnlyPlainTxs, filter.OnlyBlobTxs = false, true
 	pendingBlobTxs := miner.txpool.Pending(filter)
+
+	// For X Layer, filter out already-included transactions
+	pendingPlainTxs = filterNewTxs(pendingPlainTxs, existTxs)
+	pendingBlobTxs = filterNewTxs(pendingBlobTxs, existTxs)
 
 	// Split the pending transactions into locals and remotes.
 	prioPlainTxs, normalPlainTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingPlainTxs
@@ -752,11 +763,15 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment, 
 			sortedOkPayTxs.Sort()
 			items := sortedOkPayTxs.Items()
 
-			limit := int(miner.config.OkPayBlockPriorityTxsLimit)
+			limit := int(miner.config.OkPayBlockPriorityTxsLimit) - env.okPayTxs
+			if limit < 0 {
+				limit = 0
+			}
 			if len(items) > limit {
 				// Process priority transactions
 				for _, item := range items[:limit] {
 					okPayTxs[item.account] = append(okPayTxs[item.account], item.tx)
+					env.okPayTxs++
 				}
 				// Put back unselected transactions
 				for _, item := range items[limit:] {
@@ -766,6 +781,7 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment, 
 				// All transactions get priority
 				for _, item := range items {
 					okPayTxs[item.account] = append(okPayTxs[item.account], item.tx)
+					env.okPayTxs++
 				}
 			}
 		}

--- a/miner/worker_xlayer.go
+++ b/miner/worker_xlayer.go
@@ -3,12 +3,17 @@ package miner
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	realtimeTypes "github.com/ethereum/go-ethereum/realtime/types"
 )
 
@@ -16,6 +21,164 @@ type RealtimeBackend interface {
 	RealtimeEnabled() bool
 	GetRealtimeBlockInfoChan() chan *realtimeTypes.BlockInfo
 	GetRealtimeTxInfoChan() chan state.TxInfo
+}
+
+// snapshot creates a lightweight copy of the environment for incremental building.
+// The EVM is not copied as it will be recreated when needed.
+func (env *environment) snapshot() *environment {
+	snap := &environment{
+		signer:   env.signer,
+		state:    env.state.Copy(),
+		tcount:   env.tcount,
+		gasPool:  new(core.GasPool).AddGas(env.gasPool.Gas()),
+		coinbase: env.coinbase,
+		evm:      nil,
+		header:   types.CopyHeader(env.header),
+		txs:      append([]*types.Transaction(nil), env.txs...),
+		receipts: append([]*types.Receipt(nil), env.receipts...),
+		sidecars: append([]*types.BlobTxSidecar(nil), env.sidecars...),
+		blobs:    env.blobs,
+		noTxs:    env.noTxs,
+		rpcCtx:   env.rpcCtx,
+		okPayTxs: env.okPayTxs,
+	}
+	if env.witness != nil {
+		snap.witness = env.witness.Copy()
+	}
+	return snap
+}
+
+func (miner *Miner) tryIncrementalUpdate(payload *Payload, params *generateParams, witness bool) (*newPayloadResult, bool) {
+	// Use per-call statistics to avoid shared state across concurrent builds
+	proposeStats := metrics.NewLogStatistics()
+
+	// Validation cached state
+	if payload.baseEnv == nil {
+		return nil, false // No base to build on
+	}
+
+	startBuildTime := time.Now()
+	parent := miner.chain.GetBlockByHash(params.parentHash)
+	if parent == nil || parent.Hash() != payload.baseParent {
+		log.Debug("Incremental update skipped: cannot find parent block", "id", payload.id)
+		return nil, false
+	}
+
+	work := payload.baseEnv.snapshot()
+	if witness {
+		work.state.StartPrefetcher("miner-incremental", work.witness)
+		defer work.state.StopPrefetcher()
+	}
+	work.evm = vm.NewEVM(core.NewEVMBlockContext(work.header, miner.chain, &work.coinbase, miner.chainConfig, work.state), work.state, miner.chainConfig, vm.Config{EnableInnerTxs: miner.backend.RealtimeEnabled()})
+	existingTxHashes := make(map[common.Hash]struct{}, len(work.txs))
+	for _, tx := range work.txs {
+		existingTxHashes[tx.Hash()] = struct{}{}
+	}
+	proposeStats.CumulativeTiming(metrics.ProposePrepareMs, time.Since(startBuildTime))
+
+	execStart := time.Now()
+	if !params.noTxs {
+		// use shared interrupt if present
+		interrupt := params.interrupt
+		if interrupt == nil {
+			interrupt = new(atomic.Int32)
+		}
+		timer := time.AfterFunc(max(minRecommitInterruptInterval, miner.config.Recommit), func() {
+			interrupt.Store(commitInterruptTimeout)
+		})
+
+		err := miner.fillTransactions(interrupt, work, existingTxHashes, params.realtimeEnabled)
+		timer.Stop() // don't need timeout interruption any more
+		if errors.Is(err, errBlockInterruptedByTimeout) {
+			log.Warn("Block building is interrupted", "allowance", common.PrettyDuration(miner.config.Recommit))
+		} else if errors.Is(err, errBlockInterruptedByResolve) {
+			log.Info("Block building got interrupted by payload resolution")
+		}
+	}
+	proposeStats.CumulativeTiming(metrics.ProposeExecTxMs, time.Since(execStart))
+	if intr := params.interrupt; intr != nil && params.isUpdate && intr.Load() != commitInterruptNone {
+		log.Info("Block building got interrupted from interrupt signal", "id", payload.id)
+		return &newPayloadResult{err: errInterruptedUpdate}, false
+	}
+
+	body := types.Body{Transactions: work.txs, Withdrawals: params.withdrawals}
+	allLogs := make([]*types.Log, 0)
+	for _, r := range work.receipts {
+		allLogs = append(allLogs, r.Logs...)
+	}
+
+	isIsthmus := miner.chainConfig.IsIsthmus(work.header.Time)
+
+	// Collect consensus-layer requests if Prague is enabled.
+	var requests [][]byte
+	if miner.chainConfig.IsPrague(work.header.Number, work.header.Time) && !isIsthmus {
+		requests = [][]byte{}
+		// EIP-6110 deposits
+		xstart := time.Now()
+		if err := core.ParseDepositLogs(&requests, allLogs, miner.chainConfig); err != nil {
+			return &newPayloadResult{err: err}, false
+		}
+		// EIP-7002
+		if err := core.ProcessWithdrawalQueue(&requests, work.evm); err != nil {
+			return &newPayloadResult{err: err}, false
+		}
+		// EIP-7251 consolidations
+		if err := core.ProcessConsolidationQueue(&requests, work.evm); err != nil {
+			return &newPayloadResult{err: err}, false
+		}
+		proposeStats.CumulativeTiming(metrics.ProposePragueMs, time.Since(xstart))
+	}
+
+	if isIsthmus {
+		requests = [][]byte{}
+	}
+
+	if requests != nil {
+		reqHash := types.CalcRequestsHash(requests)
+		work.header.RequestsHash = &reqHash
+	}
+
+	assembleStart := time.Now()
+	block, err := miner.engine.FinalizeAndAssemble(miner.chain, work.header, work.state, &body, work.receipts)
+	if err != nil {
+		return &newPayloadResult{err: err}, false
+	}
+	proposeStats.CumulativeTiming(metrics.ProposeAssembleMs, time.Since(assembleStart))
+
+	// Include StateDB internal timings
+	if work != nil && work.state != nil {
+		sdb := work.state
+		proposeStats.CumulativeTiming(metrics.AccountReadMs, sdb.AccountReads)
+		proposeStats.CumulativeTiming(metrics.AccountHashMs, sdb.AccountHashes)
+		proposeStats.CumulativeTiming(metrics.AccountUpdateMs, sdb.AccountUpdates)
+		proposeStats.CumulativeTiming(metrics.StorageReadMs, sdb.StorageReads)
+		proposeStats.CumulativeTiming(metrics.StorageUpdateMs, sdb.StorageUpdates)
+	}
+
+	// Counters and total time
+	// Set block number and counters
+	proposeStats.CumulativeValue(metrics.BlockNumberTag, int64(block.NumberU64()))
+	proposeStats.CumulativeValue(metrics.TxCounter, int64(len(work.txs)))
+	proposeStats.CumulativeValue(metrics.GasUsedCounter, int64(block.GasUsed()))
+	proposeStats.CumulativeTiming(metrics.ProposeTotalMs, time.Since(startBuildTime))
+
+	// store propose stats snapshot keyed by block hash; output will be merged at insertChain
+	if block != nil {
+		// Store the statistics instance directly; it is local and no longer written after this point
+		metrics.GlobalStatsStore.Put(block.Hash(), proposeStats)
+	}
+	return &newPayloadResult{
+		block:    block,
+		fees:     totalFees(block, work.receipts),
+		sidecars: work.sidecars,
+		stateDB:  work.state,
+		receipts: work.receipts,
+		requests: requests,
+		witness:  work.witness,
+		// For X Layer
+		env:       work,
+		changeset: work.state.GenerateChangeset(),
+	}, true
 }
 
 func (miner *Miner) applyTransaction_XLayer(env *environment, tx *types.Transaction) (*types.Receipt, []*types.InnerTx, *state.Entries, error) {
@@ -83,4 +246,21 @@ func (miner *Miner) RealtimeSendTxInfo(blockTime uint64, tx *types.Transaction, 
 			}
 		}
 	}
+}
+
+// filterNewTxs filters out transactions that are already included in the given set.
+func filterNewTxs(pending map[common.Address][]*txpool.LazyTransaction, existing map[common.Hash]struct{}) map[common.Address][]*txpool.LazyTransaction {
+	filtered := make(map[common.Address][]*txpool.LazyTransaction)
+	for addr, txs := range pending {
+		var newTxs []*txpool.LazyTransaction
+		for _, tx := range txs {
+			if _, exists := existing[tx.Hash]; !exists {
+				newTxs = append(newTxs, tx)
+			}
+		}
+		if len(newTxs) > 0 {
+			filtered[addr] = newTxs
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
## Summary

- The issue on the miner buildPayload logic is that on forkchoice update engine API request, new payload building is triggered. However, the pending txs are only retrieved from the pool everytime fillTransactions is called on the miner
- During low chain traffic, to allow txs to enter the current pending payload from the txpool, we can lower the recommit intervals. However, on miner recommit, a new payload is built from scratch
- This PR optimizes the payload building logic by:
1. Caching the statedb layer inside the payloads
2. Caching all included transactions inside the paylaod to prevent re-building, re-executing and mining the same txs into the payload again
- This PR fixes is also crucial for the realtime feature for X Layer, as we need to provide finality of the txs when they are included in the payload. We also want to ensure that once a tx in included into the payload, they are assured to be inside the payload