### PR TITLE
perf(gasPrice): update config struct name for more clearly and migrate gasPrice ut 

### DIFF
--- a/core/txpool/xlayer_filter.go
+++ b/core/txpool/xlayer_filter.go
@@ -94,9 +94,9 @@ func (f *XLayerFilter) FilterTx(ctx context.Context, tx *types.Transaction) bool
 
 	// Additional filtering based on XLayer type
 	switch f.config.XLayer.Type {
-	case gasprice.FollowerType:
+	case gasprice.GasPriceFollowerType:
 		return f.filterFollowerTx(ctx, tx)
-	case gasprice.FixedType:
+	case gasprice.GasPriceFixedType:
 		return f.filterFixedTx(ctx, tx)
 	default:
 		// Default type - no additional filtering

--- a/core/txpool/xlayer_filter_test.go
+++ b/core/txpool/xlayer_filter_test.go
@@ -43,7 +43,7 @@ func (m *mockXLayerGpricer) GetLastRawGP() *big.Int {
 
 func (m *mockXLayerGpricer) GetConfig() gasprice.Config {
 	return gasprice.Config{
-		XLayer: gasprice.XLayerConfig{
+		XLayer: gasprice.XLayerGasPriceConfig{
 			Default: m.minGasPrice,
 		},
 	}
@@ -81,7 +81,7 @@ func TestNewXLayerFilter(t *testing.T) {
 		{
 			name: "With default XLayer price",
 			config: gasprice.Config{
-				XLayer: gasprice.XLayerConfig{
+				XLayer: gasprice.XLayerGasPriceConfig{
 					Default: big.NewInt(10 * params.GWei),
 				},
 			},
@@ -90,7 +90,7 @@ func TestNewXLayerFilter(t *testing.T) {
 		{
 			name: "With zero XLayer price",
 			config: gasprice.Config{
-				XLayer: gasprice.XLayerConfig{
+				XLayer: gasprice.XLayerGasPriceConfig{
 					Default: big.NewInt(0),
 				},
 			},
@@ -99,7 +99,7 @@ func TestNewXLayerFilter(t *testing.T) {
 		{
 			name: "With nil XLayer price",
 			config: gasprice.Config{
-				XLayer: gasprice.XLayerConfig{
+				XLayer: gasprice.XLayerGasPriceConfig{
 					Default: nil,
 				},
 			},
@@ -128,7 +128,7 @@ func TestNewXLayerFilter(t *testing.T) {
 
 func TestXLayerFilterFilterTx_NoXLayerConfig(t *testing.T) {
 	config := gasprice.Config{
-		XLayer: gasprice.XLayerConfig{
+		XLayer: gasprice.XLayerGasPriceConfig{
 			Type: "", // No XLayer type configured
 		},
 	}
@@ -159,8 +159,8 @@ func TestXLayerFilterFilterTx_NoXLayerConfig(t *testing.T) {
 
 func TestXLayerFilterFilterTx_LegacyTx(t *testing.T) {
 	config := gasprice.Config{
-		XLayer: gasprice.XLayerConfig{
-			Type:    gasprice.DefaultType,
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:    gasprice.GasPriceDefaultType,
 			Default: big.NewInt(10 * params.GWei),
 		},
 	}
@@ -215,8 +215,8 @@ func TestXLayerFilterFilterTx_LegacyTx(t *testing.T) {
 
 func TestXLayerFilterFilterTx_EIP1559(t *testing.T) {
 	config := gasprice.Config{
-		XLayer: gasprice.XLayerConfig{
-			Type:    gasprice.DefaultType,
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:    gasprice.GasPriceDefaultType,
 			Default: big.NewInt(10 * params.GWei),
 		},
 	}
@@ -280,8 +280,8 @@ func TestXLayerFilterFilterTx_EIP1559(t *testing.T) {
 
 func TestXLayerFilterFilterTx_NilMinPrice(t *testing.T) {
 	config := gasprice.Config{
-		XLayer: gasprice.XLayerConfig{
-			Type:    gasprice.DefaultType,
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:    gasprice.GasPriceDefaultType,
 			Default: big.NewInt(10 * params.GWei),
 		},
 	}
@@ -311,8 +311,8 @@ func TestXLayerFilterFilterTx_NilMinPrice(t *testing.T) {
 
 func TestXLayerFilterUpdateConfig(t *testing.T) {
 	initialConfig := gasprice.Config{
-		XLayer: gasprice.XLayerConfig{
-			Type:    gasprice.DefaultType,
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:    gasprice.GasPriceDefaultType,
 			Default: big.NewInt(10 * params.GWei),
 		},
 	}
@@ -332,8 +332,8 @@ func TestXLayerFilterUpdateConfig(t *testing.T) {
 		{
 			name: "Update to higher price",
 			newConfig: gasprice.Config{
-				XLayer: gasprice.XLayerConfig{
-					Type:    gasprice.DefaultType,
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:    gasprice.GasPriceDefaultType,
 					Default: big.NewInt(20 * params.GWei),
 				},
 			},
@@ -342,8 +342,8 @@ func TestXLayerFilterUpdateConfig(t *testing.T) {
 		{
 			name: "Update to zero price",
 			newConfig: gasprice.Config{
-				XLayer: gasprice.XLayerConfig{
-					Type:    gasprice.DefaultType,
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:    gasprice.GasPriceDefaultType,
 					Default: big.NewInt(0),
 				},
 			},
@@ -352,8 +352,8 @@ func TestXLayerFilterUpdateConfig(t *testing.T) {
 		{
 			name: "Update with nil price",
 			newConfig: gasprice.Config{
-				XLayer: gasprice.XLayerConfig{
-					Type:    gasprice.DefaultType,
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:    gasprice.GasPriceDefaultType,
 					Default: nil,
 				},
 			},
@@ -373,8 +373,8 @@ func TestXLayerFilterUpdateConfig(t *testing.T) {
 
 func TestXLayerFilterFilterTx_EIP1559_And_UpdatePrice(t *testing.T) {
 	config := gasprice.Config{
-		XLayer: gasprice.XLayerConfig{
-			Type:    gasprice.DefaultType,
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:    gasprice.GasPriceDefaultType,
 			Default: big.NewInt(10 * params.GWei),
 		},
 	}

--- a/core/util_xlayer_test.go
+++ b/core/util_xlayer_test.go
@@ -29,7 +29,7 @@ func TestGenerateFirstXlayerBlock(t *testing.T) {
 			setupDB: func(db ethdb.Database) {
 				// Empty database
 			},
-			expectedError: "commitXlayerFirstBlock: genesis block not found",
+			expectedError: "commitXLayerFirstBlock: genesis block not found",
 		},
 		{
 			name: "genesis block not in database",
@@ -37,7 +37,7 @@ func TestGenerateFirstXlayerBlock(t *testing.T) {
 				// Write canonical hash but no block
 				rawdb.WriteCanonicalHash(db, common.HexToHash("0x123"), 0)
 			},
-			expectedError: "commitXlayerFirstBlock: genesis block not found in database",
+			expectedError: "commitXLayerFirstBlock: genesis block not found in database",
 		},
 		{
 			name: "successful generation",
@@ -67,7 +67,7 @@ func TestGenerateFirstXlayerBlock(t *testing.T) {
 			tt.setupDB(testDB)
 
 			// Execute test
-			block, err := GenerateFirstXlayerBlock(testDB, chainConfig)
+			block, err := GenerateFirstXLayerBlock(testDB, chainConfig)
 
 			// Verify results
 			if tt.expectedError == "" {
@@ -109,7 +109,7 @@ func TestCommitXlayerFirstBlock(t *testing.T) {
 			setupDB: func(db ethdb.Database) {
 				// Empty database
 			},
-			expectedError: "commitXlayerFirstBlock: current block hash not found",
+			expectedError: "commitXLayerFirstBlock: current block hash not found",
 		},
 		{
 			name: "no current block number",
@@ -117,7 +117,7 @@ func TestCommitXlayerFirstBlock(t *testing.T) {
 				hash := common.HexToHash("0x123")
 				rawdb.WriteHeadBlockHash(db, hash)
 			},
-			expectedError: "commitXlayerFirstBlock: current block number not found",
+			expectedError: "commitXLayerFirstBlock: current block number not found",
 		},
 		{
 			name: "non-zero current block",
@@ -135,7 +135,7 @@ func TestCommitXlayerFirstBlock(t *testing.T) {
 				rawdb.WriteHeadBlockHash(db, hash)
 				rawdb.WriteHeaderNumber(db, hash, 0)
 			},
-			expectedError: "commitXlayerFirstBlock: genesis block not found",
+			expectedError: "commitXLayerFirstBlock: genesis block not found",
 		},
 		{
 			name: "successful commit",
@@ -168,7 +168,7 @@ func TestCommitXlayerFirstBlock(t *testing.T) {
 			tt.setupDB(testDB)
 
 			// Execute test
-			err := CommitXlayerFirstBlock(testDB, chainConfig)
+			err := CommitXLayerFirstBlock(testDB, chainConfig)
 
 			// Verify results
 			if tt.expectedError == "" {
@@ -225,7 +225,7 @@ func TestCommitXlayerFirstBlock_WithGenesisBlock(t *testing.T) {
 	rawdb.WriteHeaderNumber(db, genesisBlock.Hash(), 0)
 
 	// Execute test
-	err := CommitXlayerFirstBlock(db, chainConfig)
+	err := CommitXLayerFirstBlock(db, chainConfig)
 	assert.NoError(t, err)
 
 	// Verify the xlayer block

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -54,7 +54,7 @@ type Config struct {
 	MinSuggestedPriorityFee *big.Int `toml:",omitempty"` // for Optimism fee suggestion
 
 	// For X Layer
-	XLayer XLayerConfig
+	XLayer XLayerGasPriceConfig
 }
 
 // OracleBackend includes all necessary background APIs for oracle.

--- a/eth/gasprice/gasprice_xlayer.go
+++ b/eth/gasprice/gasprice_xlayer.go
@@ -9,13 +9,13 @@ import (
 
 // XLayer gas price types
 const (
-	DefaultType  = "default"  // Default gas price from config
-	FollowerType = "follower" // Calculate gas price based on L1 gas price
-	FixedType    = "fixed"    // Fixed gas price in USDT
+	GasPriceDefaultType  = "default"  // Default gas price from config
+	GasPriceFollowerType = "follower" // Calculate gas price based on L1 gas price
+	GasPriceFixedType    = "fixed"    // Fixed gas price in USDT
 )
 
-// XLayerConfig is the X Layer gas price config
-type XLayerConfig struct {
+// XLayerGasPriceConfig is the X Layer gas price config
+type XLayerGasPriceConfig struct {
 	Type         string        `toml:",omitempty"`
 	UpdatePeriod time.Duration `toml:",omitempty"`
 	Factor       float64       `toml:",omitempty"`

--- a/eth/gasprice/xlayer/fixed_xlayer_test.go
+++ b/eth/gasprice/xlayer/fixed_xlayer_test.go
@@ -1,0 +1,143 @@
+package xlayer
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/eth/gasprice"
+)
+
+func TestUpdateGasPriceFixed(t *testing.T) {
+	ctx := context.Background()
+	var d time.Duration = 1000000000
+	cfg := gasprice.Config{
+		MaxPrice: new(big.Int).SetUint64(0),
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:               gasprice.GasPriceFixedType,
+			UpdatePeriod:       d,
+			Factor:             0.5,
+			KafkaURL:           "127.0.0.1:9092",
+			Topic:              "middle_coinPrice_push",
+			DefaultL2CoinPrice: 40,
+			GasPriceUsdt:       0.001,
+			Default:            new(big.Int).SetUint64(1000000000),
+		},
+	}
+	l1GasPrice := big.NewInt(10000000000)
+	f := newFixedGasPriceSuggester(ctx, cfg)
+
+	f.UpdateGasPriceAvg(l1GasPrice)
+}
+
+func TestUpdateGasPriceAvgCases(t *testing.T) {
+	var d time.Duration = 1000000000
+	testcases := []struct {
+		cfg        gasprice.Config
+		l1GasPrice *big.Int
+		l2GasPrice uint64
+	}{
+		{
+			cfg: gasprice.Config{
+				MaxPrice: new(big.Int).SetUint64(0),
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:               gasprice.GasPriceFixedType,
+					UpdatePeriod:       d,
+					KafkaURL:           "127.0.0.1:9092",
+					Topic:              "middle_coinPrice_push",
+					DefaultL2CoinPrice: 40,
+					GasPriceUsdt:       0.001,
+					Default:            new(big.Int).SetUint64(1000000000),
+				},
+			},
+			l1GasPrice: big.NewInt(10000000000),
+			l2GasPrice: uint64(25000000000000),
+		},
+		{
+			cfg: gasprice.Config{
+				MaxPrice: new(big.Int).SetUint64(0),
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:               gasprice.GasPriceFixedType,
+					UpdatePeriod:       d,
+					KafkaURL:           "127.0.0.1:9092",
+					Topic:              "middle_coinPrice_push",
+					DefaultL2CoinPrice: 1e-19,
+					GasPriceUsdt:       0.001,
+					Default:            new(big.Int).SetUint64(1000000000),
+				},
+			},
+			l1GasPrice: big.NewInt(10000000000),
+			l2GasPrice: uint64(25000000000000),
+		},
+		{ // the gas price less than the min gas price
+			cfg: gasprice.Config{
+				MaxPrice: new(big.Int).SetUint64(0),
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:               gasprice.GasPriceFixedType,
+					UpdatePeriod:       d,
+					KafkaURL:           "127.0.0.1:9092",
+					Topic:              "middle_coinPrice_push",
+					DefaultL2CoinPrice: 40,
+					GasPriceUsdt:       0.001,
+					Default:            new(big.Int).SetUint64(26000000000000),
+				},
+			},
+			l1GasPrice: big.NewInt(10000000000),
+			l2GasPrice: uint64(26000000000000),
+		},
+		{ // the gas price bigger than the max gas price
+			cfg: gasprice.Config{
+				MaxPrice: new(big.Int).SetUint64(23000000000000),
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:               gasprice.GasPriceFixedType,
+					UpdatePeriod:       d,
+					KafkaURL:           "127.0.0.1:9092",
+					Topic:              "middle_coinPrice_push",
+					DefaultL2CoinPrice: 40,
+					GasPriceUsdt:       0.001,
+					Default:            new(big.Int).SetUint64(1000000000000),
+				},
+			},
+			l1GasPrice: big.NewInt(10000000000),
+			l2GasPrice: uint64(23000000000000),
+		},
+		{
+			cfg: gasprice.Config{
+				MaxPrice: new(big.Int).SetUint64(0),
+				XLayer: gasprice.XLayerGasPriceConfig{
+					UpdatePeriod:       d,
+					KafkaURL:           "127.0.0.1:9092",
+					Topic:              "middle_coinPrice_push",
+					DefaultL2CoinPrice: 30,
+					GasPriceUsdt:       0.001,
+					Default:            new(big.Int).SetUint64(1000000000),
+				},
+			},
+			l1GasPrice: big.NewInt(10000000000),
+			l2GasPrice: uint64(33300000000000),
+		},
+		{
+			cfg: gasprice.Config{
+				MaxPrice: new(big.Int).SetUint64(0),
+				XLayer: gasprice.XLayerGasPriceConfig{
+					Type:               gasprice.GasPriceFixedType,
+					UpdatePeriod:       d,
+					KafkaURL:           "127.0.0.1:9092",
+					Topic:              "middle_coinPrice_push",
+					DefaultL2CoinPrice: 30,
+					GasPriceUsdt:       1e-15,
+					Default:            new(big.Int).SetUint64(10),
+				},
+			},
+			l1GasPrice: big.NewInt(10000000000),
+			l2GasPrice: uint64(33),
+		},
+	}
+
+	for _, tc := range testcases {
+		ctx := context.Background()
+		f := newFixedGasPriceSuggester(ctx, tc.cfg)
+		f.UpdateGasPriceAvg(tc.l1GasPrice)
+	}
+}

--- a/eth/gasprice/xlayer/follower_xlayer_test.go
+++ b/eth/gasprice/xlayer/follower_xlayer_test.go
@@ -1,0 +1,64 @@
+package xlayer
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/eth/gasprice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFollowerUpdateGasPrice(t *testing.T) {
+	ctx := context.Background()
+	var d time.Duration = 1000000000
+
+	cfg := gasprice.Config{
+		MaxPrice: new(big.Int).SetUint64(0),
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:               gasprice.GasPriceFollowerType,
+			UpdatePeriod:       d,
+			KafkaURL:           "127.0.0.1:9092",
+			Topic:              "middle_coinPrice_push",
+			Factor:             0.5,
+			DefaultL1CoinPrice: 1,
+			DefaultL2CoinPrice: 1,
+			Default:            new(big.Int).SetUint64(1000000000),
+		},
+	}
+	l1GasPrice := big.NewInt(10000000000)
+	f := newFollowerGasPriceSuggester(ctx, cfg)
+
+	f.UpdateGasPriceAvg(l1GasPrice)
+
+	// Calculate correct GP
+	// Correct GP: L1/L2 ratio = 1, l1GasPrice * 1 * Factor
+	correctGpVal := big.NewFloat(0).Mul(big.NewFloat(0).SetFloat64(cfg.XLayer.Factor), big.NewFloat(0).SetInt(l1GasPrice))
+	correctGp := new(big.Int)
+	correctGpVal.Int(correctGp)
+	require.Equal(t, correctGp.Uint64(), f.GetLastRawGP().Uint64())
+}
+
+func TestMaxGasPriceLimit(t *testing.T) {
+	ctx := context.Background()
+	var d time.Duration = 1000000000
+
+	cfg := gasprice.Config{
+		MaxPrice: new(big.Int).SetUint64(50000000),
+		XLayer: gasprice.XLayerGasPriceConfig{
+			Type:               gasprice.GasPriceFollowerType,
+			UpdatePeriod:       d,
+			KafkaURL:           "127.0.0.1:9092",
+			Topic:              "middle_coinPrice_push",
+			Factor:             0.5,
+			DefaultL1CoinPrice: 1,
+			DefaultL2CoinPrice: 1,
+			Default:            new(big.Int).SetUint64(100000000),
+		},
+	}
+	l1GasPrice := big.NewInt(1000000000)
+	f := newFollowerGasPriceSuggester(ctx, cfg)
+	f.UpdateGasPriceAvg(l1GasPrice)
+	require.Equal(t, f.GetLastRawGP().Uint64(), cfg.MaxPrice.Uint64())
+}

--- a/eth/gasprice/xlayer/gaspricesuggester_xlayer.go
+++ b/eth/gasprice/xlayer/gaspricesuggester_xlayer.go
@@ -27,13 +27,13 @@ type L2GasPricer interface {
 func NewL2GasPriceSuggester(ctx context.Context, cfg gasprice.Config) L2GasPricer {
 	var gpricer L2GasPricer
 	switch cfg.XLayer.Type {
-	case gasprice.FollowerType:
+	case gasprice.GasPriceFollowerType:
 		log.Info("Follower type selected")
 		gpricer = newFollowerGasPriceSuggester(ctx, cfg)
-	case gasprice.DefaultType:
+	case gasprice.GasPriceDefaultType:
 		log.Info("Default type selected")
 		gpricer = newDefaultGasPriceSuggester(ctx, cfg)
-	case gasprice.FixedType:
+	case gasprice.GasPriceFixedType:
 		log.Info("Fixed type selected")
 		gpricer = newFixedGasPriceSuggester(ctx, cfg)
 	default:

--- a/eth/gasprice/xlayer/kafka_proc_xlayer.go
+++ b/eth/gasprice/xlayer/kafka_proc_xlayer.go
@@ -82,7 +82,7 @@ type L1L2PriceRecord struct {
 
 // KafkaProcessor kafka processor
 type KafkaProcessor struct {
-	cfg       gasprice.XLayerConfig
+	cfg       gasprice.XLayerGasPriceConfig
 	kreader   *kafka.Reader
 	ctx       context.Context
 	rwLock    sync.RWMutex
@@ -93,7 +93,7 @@ type KafkaProcessor struct {
 	tmpPrices L1L2PriceRecord
 }
 
-func newKafkaProcessor(cfg gasprice.XLayerConfig, ctx context.Context) *KafkaProcessor {
+func newKafkaProcessor(cfg gasprice.XLayerGasPriceConfig, ctx context.Context) *KafkaProcessor {
 	rp := &KafkaProcessor{
 		cfg:      cfg,
 		kreader:  getKafkaReader(cfg),
@@ -114,7 +114,7 @@ func newKafkaProcessor(cfg gasprice.XLayerConfig, ctx context.Context) *KafkaPro
 	return rp
 }
 
-func getKafkaReader(cfg gasprice.XLayerConfig) *kafka.Reader {
+func getKafkaReader(cfg gasprice.XLayerGasPriceConfig) *kafka.Reader {
 	brokers := strings.Split(cfg.KafkaURL, ",")
 
 	var dialer *kafka.Dialer
@@ -179,13 +179,13 @@ func (rp *KafkaProcessor) ReadAndUpdate(ctx context.Context) error {
 
 // Update update the coin price
 func (rp *KafkaProcessor) Update(data []byte) error {
-	if rp.cfg.Type == gasprice.FixedType {
+	if rp.cfg.Type == gasprice.GasPriceFixedType {
 		price, err := rp.parseCoinPrice(data, []int{rp.l2CoinId})
 		if err == nil {
 			rp.updateL2CoinPrice(price[rp.l2CoinId])
 		}
 		return err
-	} else if rp.cfg.Type == gasprice.FollowerType {
+	} else if rp.cfg.Type == gasprice.GasPriceFollowerType {
 		prices, err := rp.parseCoinPrice(data, []int{rp.l1CoinId, rp.l2CoinId})
 		if err == nil {
 			rp.updateL1L2CoinPrice(prices)

--- a/eth/gasprice/xlayer/kafka_proc_xlayer_test.go
+++ b/eth/gasprice/xlayer/kafka_proc_xlayer_test.go
@@ -1,0 +1,256 @@
+package xlayer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/eth/gasprice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCoinPrice(t *testing.T) {
+	testcases := []struct {
+		coinIds []int
+		msg     string
+		check   func(prices map[int]float64, err error)
+	}{
+		{
+			// param err
+			coinIds: []int{},
+			msg:     "{\"topic\":\"middle_coinPrice_push\"}",
+			check: func(prices map[int]float64, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			// param err
+			coinIds: []int{ethcoinId, okbcoinId},
+			msg:     "{\"topic\":\"middle_coinPrice_push\"}",
+			check: func(prices map[int]float64, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			// not find all, find one
+			coinIds: []int{ethcoinId, okbcoinId},
+			msg:     fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.02}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId),
+			check: func(prices map[int]float64, err error) {
+				require.NoError(t, err)
+				require.Equal(t, prices[ethcoinId], 0.02)
+			},
+		},
+		{
+			// not find all
+			coinIds: []int{ethcoinId, okbcoinId},
+			msg:     fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.02}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", okbcoinId),
+			check: func(prices map[int]float64, err error) {
+				require.NoError(t, err)
+				require.Equal(t, prices[okbcoinId], 0.02)
+			},
+		},
+		{
+			// correct
+			coinIds: []int{ethcoinId, okbcoinId, okbcoinId + 1},
+			msg:     fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.001}, {\"coinId\":%d,\"price\":0.002}, {\"coinId\":%d,\"price\":0.003}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId, okbcoinId, okbcoinId+1),
+			check: func(prices map[int]float64, err error) {
+				require.NoError(t, err)
+				require.Equal(t, len(prices), 3)
+				require.Equal(t, prices[ethcoinId], 0.001)
+				require.Equal(t, prices[okbcoinId], 0.002)
+				require.Equal(t, prices[okbcoinId+1], 0.003)
+			},
+		},
+		{
+			// correct
+			coinIds: []int{ethcoinId, okbcoinId},
+			msg:     fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.02}, {\"coinId\":%d,\"price\":0.002}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId, okbcoinId),
+			check: func(prices map[int]float64, err error) {
+				require.NoError(t, err)
+				require.Equal(t, len(prices), 2)
+				require.Equal(t, prices[ethcoinId], 0.02)
+				require.Equal(t, prices[okbcoinId], 0.002)
+			},
+		},
+		{
+			// correct
+			coinIds: []int{ethcoinId, okbcoinId},
+			msg:     fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.02}, {\"coinId\":%d,\"price\":0.002}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", okbcoinId, ethcoinId),
+			check: func(prices map[int]float64, err error) {
+				require.NoError(t, err)
+				require.Equal(t, len(prices), 2)
+				require.Equal(t, prices[ethcoinId], 0.002)
+				require.Equal(t, prices[okbcoinId], 0.02)
+			},
+		},
+		{
+			// correct
+			coinIds: []int{okbcoinId, ethcoinId},
+			msg:     fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.02}, {\"coinId\":%d,\"price\":0.002}, {\"coinId\":%d,\"price\":0.003}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", okbcoinId, ethcoinId, ethcoinId+1),
+			check: func(prices map[int]float64, err error) {
+				require.NoError(t, err)
+				require.Equal(t, len(prices), 2)
+				require.Equal(t, prices[okbcoinId], 0.02)
+				require.Equal(t, prices[ethcoinId], 0.002)
+			},
+		},
+		{
+			// correct
+			coinIds: []int{okbcoinId},
+			msg:     fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.04}, {\"coinId\":%d,\"price\":0.002}, {\"coinId\":123,\"price\":0.005}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId, okbcoinId),
+			check: func(prices map[int]float64, err error) {
+				require.NoError(t, err)
+				require.Equal(t, len(prices), 1)
+				require.Equal(t, prices[okbcoinId], 0.002)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		rp := newKafkaProcessor(gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push"}, context.Background())
+		rt, err := rp.parseCoinPrice([]byte(tc.msg), tc.coinIds)
+		tc.check(rt, err)
+	}
+}
+
+func TestUpdateL1L2CoinPrice(t *testing.T) {
+	testcases := []struct {
+		check func()
+	}{
+		{
+			check: func() {
+				rp := newKafkaProcessor(gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push"}, context.Background())
+				prices := map[int]float64{ethcoinId: 1.5, okbcoinId: 0.5}
+				rp.updateL1L2CoinPrice(prices)
+				l1, l2 := rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, 1.5)
+				require.Equal(t, l2, 0.5)
+			},
+		},
+		{
+			check: func() {
+				rp := newKafkaProcessor(gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push"}, context.Background())
+				prices := map[int]float64{ethcoinId: 1.5}
+				rp.updateL1L2CoinPrice(prices)
+				l1, l2 := rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, 0.0)
+				require.Equal(t, l2, 0.0)
+				require.Equal(t, rp.tmpPrices.l1Update, true)
+				require.Equal(t, rp.tmpPrices.l2Update, false)
+
+				prices = map[int]float64{okbcoinId: 0.5}
+				rp.updateL1L2CoinPrice(prices)
+				l1, l2 = rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, 1.5)
+				require.Equal(t, l2, 0.5)
+				require.Equal(t, rp.tmpPrices.l1Update, false)
+				require.Equal(t, rp.tmpPrices.l2Update, false)
+			},
+		},
+		{
+			check: func() {
+				rp := newKafkaProcessor(gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push"}, context.Background())
+				prices := map[int]float64{okbcoinId: 0.5}
+				rp.updateL1L2CoinPrice(prices)
+				l1, l2 := rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, 0.0)
+				require.Equal(t, l2, 0.0)
+				require.Equal(t, rp.tmpPrices.l1Update, false)
+				require.Equal(t, rp.tmpPrices.l2Update, true)
+
+				prices = map[int]float64{ethcoinId: 1.5}
+				rp.updateL1L2CoinPrice(prices)
+				l1, l2 = rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, 1.5)
+				require.Equal(t, l2, 0.5)
+				require.Equal(t, rp.tmpPrices.l1Update, false)
+				require.Equal(t, rp.tmpPrices.l2Update, false)
+			},
+		},
+	}
+	for _, tc := range testcases {
+		tc.check()
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	testcases := []struct {
+		msg   string
+		cfg   gasprice.XLayerGasPriceConfig
+		check func(rp *KafkaProcessor, err error)
+	}{
+		// GasPriceFixedType
+		{ // correct
+			msg: fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.04}, {\"coinId\":%d,\"price\":0.002}, {\"coinId\":123,\"price\":0.005}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId, okbcoinId),
+			cfg: gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push", Type: gasprice.GasPriceFixedType},
+			check: func(rp *KafkaProcessor, err error) {
+				require.NoError(t, err)
+				require.Equal(t, rp.GetL2CoinPrice(), 0.002)
+			},
+		},
+		{ // not find
+			msg: fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.04}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId),
+			cfg: gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push", Type: gasprice.GasPriceFixedType},
+			check: func(rp *KafkaProcessor, err error) {
+				require.Equal(t, err, ErrNotFindCoinPrice)
+				require.Equal(t, rp.GetL2CoinPrice(), float64(0))
+			},
+		},
+		{ // not find
+			msg: "{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}",
+			cfg: gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push", Type: gasprice.GasPriceFixedType},
+			check: func(rp *KafkaProcessor, err error) {
+				require.EqualError(t, err, "the data PriceList is empty")
+				require.Equal(t, rp.GetL2CoinPrice(), float64(0))
+			},
+		},
+
+		// GasPriceFollowerType
+		{ // correct
+			msg: fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.04}, {\"coinId\":%d,\"price\":0.002}, {\"coinId\":123,\"price\":0.005}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId, okbcoinId),
+			cfg: gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push", Type: gasprice.GasPriceFollowerType},
+			check: func(rp *KafkaProcessor, err error) {
+				require.NoError(t, err)
+				l1, l2 := rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, 0.04)
+				require.Equal(t, l2, 0.002)
+			},
+		},
+		{ // not find
+			msg: fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.04}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId+1),
+			cfg: gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push", Type: gasprice.GasPriceFollowerType},
+			check: func(rp *KafkaProcessor, err error) {
+				require.Equal(t, err, ErrNotFindCoinPrice)
+				l1, l2 := rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, float64(0))
+				require.Equal(t, l2, float64(0))
+			},
+		},
+		{ // find one but not update
+			msg: fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.04}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", ethcoinId),
+			cfg: gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push", Type: gasprice.GasPriceFollowerType},
+			check: func(rp *KafkaProcessor, err error) {
+				require.NoError(t, err)
+				l1, l2 := rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, float64(0))
+				require.Equal(t, l2, float64(0))
+			},
+		},
+		{ // find one but not update
+			msg: fmt.Sprintf("{\"topic\":\"middle_coinPrice_push\",\"source\":null,\"type\":null,\"data\":{\"priceList\":[{\"coinId\":%d,\"price\":0.04}],\"id\":\"98a797ce-f61b-4e90-87ac-445e77ad3599\"}}", okbcoinId),
+			cfg: gasprice.XLayerGasPriceConfig{Topic: "middle_coinPrice_push", Type: gasprice.GasPriceFollowerType},
+			check: func(rp *KafkaProcessor, err error) {
+				require.NoError(t, err)
+				l1, l2 := rp.GetL1L2CoinPrice()
+				require.Equal(t, l1, float64(0))
+				require.Equal(t, l2, float64(0))
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		rp := newKafkaProcessor(tc.cfg, context.Background())
+		err := rp.Update([]byte(tc.msg))
+		tc.check(rp, err)
+	}
+}


### PR DESCRIPTION
This pull request refactors the XLayer gas price configuration, types, and related logic to improve clarity and consistency. The main changes include renaming configuration types and constants for better readability, updating all related code and tests to use the new names, and adding new unit tests for the fixed and follower gas price suggesters.

**Refactoring and Renaming for Consistency:**

* Renamed `XLayerConfig` to `XLayerGasPriceConfig` and updated all references in code and tests to use the new name for improved clarity. (`eth/gasprice/gasprice.go`, `eth/gasprice/gasprice_xlayer.go`, `eth/gasprice/xlayer/gaspricesuggester_xlayer.go`, `eth/gasprice/xlayer/kafka_proc_xlayer.go`, `core/txpool/xlayer_filter.go`, `core/txpool/xlayer_filter_test.go`) [[1]](diffhunk://#diff-282526dd0f2b043c5e02f9b297be4a176ac15ab17236d2b47399fd3e61651a3fL12-R18) [[2]](diffhunk://#diff-c16c4a8c9f5ecfc12da6b841a10635af1d842c6f5aa9f0229fc817aa8aa80222L57-R57) [[3]](diffhunk://#diff-45c54f0874de036c8f580cbc5d6841aa206a776396f938ee51635e5f8a19ea1dL85-R85) [[4]](diffhunk://#diff-45c54f0874de036c8f580cbc5d6841aa206a776396f938ee51635e5f8a19ea1dL96-R96) [[5]](diffhunk://#diff-45c54f0874de036c8f580cbc5d6841aa206a776396f938ee51635e5f8a19ea1dL117-R117) [[6]](diffhunk://#diff-d31278fb4be011b1c538f2a0edc4abc26e2e17a7b1bd4cd5a896c6e79e99bceeL97-R99) [[7]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL46-R46) [[8]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL84-R84) [[9]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL93-R93) [[10]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL102-R102) [[11]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL131-R131) [[12]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL162-R163) [[13]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL218-R219) [[14]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL283-R284) [[15]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL314-R315) [[16]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL335-R336) [[17]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL345-R346) [[18]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL355-R356) [[19]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL376-R377) [[20]](diffhunk://#diff-2640bbd96b8d261e3b0bc2efb47495146d158e14d8b47229c11f4ac9b73fc89cL30-R36)

* Renamed gas price type constants (`DefaultType`, `FollowerType`, `FixedType`) to `GasPriceDefaultType`, `GasPriceFollowerType`, and `GasPriceFixedType`, and updated their usage throughout the codebase. (`eth/gasprice/gasprice_xlayer.go`, `core/txpool/xlayer_filter.go`, `eth/gasprice/xlayer/gaspricesuggester_xlayer.go`, `core/txpool/xlayer_filter_test.go`) [[1]](diffhunk://#diff-282526dd0f2b043c5e02f9b297be4a176ac15ab17236d2b47399fd3e61651a3fL12-R18) [[2]](diffhunk://#diff-d31278fb4be011b1c538f2a0edc4abc26e2e17a7b1bd4cd5a896c6e79e99bceeL97-R99) [[3]](diffhunk://#diff-2640bbd96b8d261e3b0bc2efb47495146d158e14d8b47229c11f4ac9b73fc89cL30-R36) [[4]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL162-R163) [[5]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL218-R219) [[6]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL283-R284) [[7]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL314-R315) [[8]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL335-R336) [[9]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL345-R346) [[10]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL355-R356) [[11]](diffhunk://#diff-0b66a652f38fe0b568f77873f683da05011743cf4b1c2588ceb730b87ff0601dL376-R377)

**Testing Improvements:**

* Added new unit tests for the fixed and follower gas price suggesters to ensure correct behavior under various configuration scenarios. (`eth/gasprice/xlayer/fixed_xlayer_test.go`, `eth/gasprice/xlayer/follower_xlayer_test.go`) [[1]](diffhunk://#diff-85b85e88e4ae5fb59e31409960c786bbe193e94688f1c137d4fca6514b9ab9a6R1-R143) [[2]](diffhunk://#diff-ff612e5ad4c8d507dcde57911d5e3b6335e3e86b66b285e2971203fedc940f0cR1-R64)

**Minor Naming Corrections:**

* Standardized function and error message naming from `Xlayer` to `XLayer` in utility test files for consistency. (`core/util_xlayer_test.go`) [[1]](diffhunk://#diff-17e06fc208190eaf5f781b39403e7608819d503a856810d4aaccb5da8a2cff1bL32-R40) [[2]](diffhunk://#diff-17e06fc208190eaf5f781b39403e7608819d503a856810d4aaccb5da8a2cff1bL70-R70) [[3]](diffhunk://#diff-17e06fc208190eaf5f781b39403e7608819d503a856810d4aaccb5da8a2cff1bL112-R120) [[4]](diffhunk://#diff-17e06fc208190eaf5f781b39403e7608819d503a856810d4aaccb5da8a2cff1bL138-R138) [[5]](diffhunk://#diff-17e06fc208190eaf5f781b39403e7608819d503a856810d4aaccb5da8a2cff1bL171-R171) [[6]](diffhunk://#diff-17e06fc208190eaf5f781b39403e7608819d503a856810d4aaccb5da8a2cff1bL228-R228)

These changes collectively improve code readability, maintainability, and test coverage for the XLayer gas price logic.