### PR TITLE
Content() Pending() ToJournal() Lock -> RLock

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -514,8 +514,8 @@ func (pool *LegacyPool) SetIngressFilters(filters []txpool.IngressFilter) {
 // Content retrieves the data content of the transaction pool, returning all the
 // pending as well as queued transactions, grouped by account and sorted by nonce.
 func (pool *LegacyPool) Content() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction) {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
 
 	pending := make(map[common.Address][]*types.Transaction, len(pool.pending))
 	for addr, list := range pool.pending {
@@ -549,8 +549,8 @@ func (pool *LegacyPool) ContentFrom(addr common.Address) ([]*types.Transaction, 
 //
 // OP-Stack addition.
 func (pool *LegacyPool) ToJournal() map[common.Address]types.Transactions {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
 
 	txs := make(map[common.Address]types.Transactions, len(pool.pending)+len(pool.queue))
 	for addr, pending := range pool.pending {
@@ -577,8 +577,8 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.OnlyBlobTxs {
 		return nil
 	}
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
 
 	pending := make(map[common.Address][]*txpool.LazyTransaction, len(pool.pending))
 	for addr, list := range pool.pending {


### PR DESCRIPTION
According to upstream go-ethereum maintainers and after an analysis, though `SortedMap` is not thread-safe, the upper design pattern has dealt with the concurrent access. Modifying methods like `Put` and `Forward` are warped by `Lock` in the upper callers. And `Flatten` is read only method, in which the cache is protected by its own `m.cacheMu.Lock`.
Plus, `ContentFrom` method already uses `RLock`, so it's safe to do this conversion.
https://github.com/ethereum/go-ethereum/pull/32924
This PR in go-ethereum is highly likely to be merged. We can modify this at first.