### PR TITLE
chore: fix failing unit test

### DIFF
--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -188,7 +188,7 @@ func TestCustomBackend(t *testing.T) {
 		},
 		{ // Reject invalid backend choice
 			initArgs:   []string{"--db.engine", "mssql"},
-			initExpect: `Fatal: Invalid choice for db.engine 'mssql', allowed 'leveldb' or 'pebble'`,
+			initExpect: `Fatal: Invalid choice for db.engine 'mssql', allowed 'leveldb' or 'pebble' or 'rocksdb'`,
 			// Since the init fails, this will return the (default) mainnet genesis
 			// block nonce
 			execExpect: `0x0000000000000042`,

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -314,7 +314,7 @@ func (f *chainFreezer) freezeRange(nfdb *nofreezedb, number, limit uint64) (hash
 
 		for ; number <= limit; number++ {
 			// save empty data for legacy blocks
-			if number < config.LegacyXLayerBlock.Uint64() && number != 0 {
+			if config.IsXLayer() && number < config.LegacyXLayerBlock.Uint64() && number != 0 {
 				if err := op.AppendRaw(ChainFreezerHashTable, number, []byte{}); err != nil {
 					return fmt.Errorf("can't write hash to Freezer: %v", err)
 				}


### PR DESCRIPTION
# Summary
There were originally two failing unit tests when the test was run with `go test ./... -tags=skip_smoke`, skipping E2E smoke tests. This PR fixes the two failing unit tests.

## Failing Test 1
### Issue 
- Core Package Panic - Nil Pointer Dereference
- Location: core/rawdb/chain_freezer.go:317
- Problem: Code attempts to call .Uint64() on config.LegacyXLayerBlock without checking if it's nil first. This causes a segmentation fault.
<img width="1658" height="718" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/9a81f1c9-5159-46f2-ac8a-b0e07dd42a72" />

### Fix
Add nil check before dereferencing config.LegacyXLayerBlock, consistent with existing patterns in params/config.go (lines 948-954).

## Failing Test 2
### Issue
TestCustomBackend - Error Message Mismatch
- Location: cmd/geth/genesis_test.go
- Problem: Test expectation doesn't match actual error message after RocksDB support was added.
<img width="1860" height="180" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/8a73f0a8-4b43-4c4a-bbf6-e3cabffa0d6f" />

### Fix
Update test expectation to include 'rocksdb' in the error message.
