### PR TITLE
Feat: Support block hash for block inner transactions

### DIFF
--- a/eth/api_legacy_xlayer.go
+++ b/eth/api_legacy_xlayer.go
@@ -397,13 +397,15 @@ func (api *XlayerHybridBlockChainAPI) GetCode(ctx context.Context, address commo
 type XlayerHybridTransactionAPI struct {
 	*ethapi.TransactionAPI
 	legacyRpc *XlayerLegacyRPCService
+	backend   ethapi.Backend
 }
 
 // NewXlayerHybridTransactionAPI creates a new migration-aware TransactionAPI
-func NewXlayerHybridTransactionAPI(original *ethapi.TransactionAPI, config *XlayerLegacyRPCService) *XlayerHybridTransactionAPI {
+func NewXlayerHybridTransactionAPI(original *ethapi.TransactionAPI, config *XlayerLegacyRPCService, backend ethapi.Backend) *XlayerHybridTransactionAPI {
 	return &XlayerHybridTransactionAPI{
 		TransactionAPI: original,
 		legacyRpc:      config,
+		backend:        backend,
 	}
 }
 
@@ -462,15 +464,56 @@ func (api *XlayerHybridTransactionAPI) GetBlockTransactionCountByNumber(ctx cont
 }
 
 // eth_getBlockInternalTransactions FORWARD
-func (api *XlayerHybridTransactionAPI) GetBlockInternalTransactions(ctx context.Context, blockNr rpc.BlockNumber) (map[common.Hash][]*types.InnerTx, error) {
+func (api *XlayerHybridTransactionAPI) GetBlockInternalTransactions(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (map[common.Hash][]*types.InnerTx, error) {
+	var blockNum uint64
+	var shouldProxyToErigon bool
+
+	// Extract block number for proxy decision
+	if num, ok := blockNrOrHash.Number(); ok {
+		// Block number provided directly
+		blockNum = uint64(num)
+		shouldProxyToErigon = api.legacyRpc.shouldProxy(blockNum)
+	} else if blockHash, ok := blockNrOrHash.Hash(); ok {
+		// Try to get block from local database first
+		block, err := api.backend.BlockByHash(ctx, blockHash)
+		if err != nil || block == nil {
+			// Block not found locally - query Erigon to get block number
+			var blockInfo map[string]interface{}
+			err := api.legacyRpc.ErigonClient.CallContext(ctx, &blockInfo, "eth_getBlockByHash", blockHash, false)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get block from Erigon: %w", err)
+			}
+			if blockInfo == nil {
+				return nil, fmt.Errorf("block not found")
+			}
+			// Extract block number from the response
+			if numberHex, ok := blockInfo["number"].(string); ok {
+				blockNumBig, err := hexutil.DecodeBig(numberHex)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode block number: %w", err)
+				}
+				blockNum = blockNumBig.Uint64()
+			} else {
+				return nil, fmt.Errorf("block number not found in response")
+			}
+			shouldProxyToErigon = true
+		} else {
+			// Block found locally
+			blockNum = block.NumberU64()
+			shouldProxyToErigon = api.legacyRpc.shouldProxy(blockNum)
+		}
+	} else {
+		return nil, errors.New("invalid block number or hash")
+	}
+
 	// Check if we should proxy to erigon
-	if api.legacyRpc.shouldProxy(uint64(blockNr)) {
+	if shouldProxyToErigon {
 		var result map[common.Hash][]*types.InnerTx
-		err := api.legacyRpc.ErigonClient.CallContext(ctx, &result, "eth_getBlockInternalTransactions", hexutil.Uint64(blockNr))
+		err := api.legacyRpc.ErigonClient.CallContext(ctx, &result, "eth_getBlockInternalTransactions", hexutil.Uint64(blockNum))
 		return result, err
 	}
-	// Handle locally
-	return api.TransactionAPI.GetBlockInternalTransactions(ctx, blockNr)
+
+	return api.TransactionAPI.GetBlockInternalTransactions(ctx, blockNrOrHash)
 }
 
 // eth_getInternalTransactions TransactionAPI LOCAL
@@ -780,7 +823,7 @@ func (api *XlayerHybridFilterAPI) GetLogs(ctx context.Context, crit filters.Filt
 }
 
 // WrapAPIsForXlayer wraps the standard APIs with migration-aware versions
-func WrapAPIsForXlayer(apis []rpc.API, config *XlayerLegacyRPCService) []rpc.API {
+func WrapAPIsForXlayer(apis []rpc.API, config *XlayerLegacyRPCService, backend ethapi.Backend) []rpc.API {
 	if config == nil {
 		return apis // No migration configured, return original APIs
 	}
@@ -805,7 +848,7 @@ func WrapAPIsForXlayer(apis []rpc.API, config *XlayerLegacyRPCService) []rpc.API
 				wrapped = append(wrapped, rpc.API{
 					Namespace:     api.Namespace,
 					Version:       api.Version,
-					Service:       NewXlayerHybridTransactionAPI(original, config),
+					Service:       NewXlayerHybridTransactionAPI(original, config, backend),
 					Public:        api.Public,
 					Authenticated: api.Authenticated,
 				})

--- a/eth/api_legacy_xlayer_test.go
+++ b/eth/api_legacy_xlayer_test.go
@@ -570,7 +570,7 @@ func TestHybridTransactionAPI_ProxiesByNumber(t *testing.T) {
 		t.Fatalf("failed to create legacy service: %v", err)
 	}
 	defer legacy.Close()
-	api := NewXlayerHybridTransactionAPI(nil, legacy)
+	api := NewXlayerHybridTransactionAPI(nil, legacy, nil)
 
 	ctx := context.Background()
 
@@ -965,7 +965,7 @@ func TestLocalStrategy_TransactionAPIs(t *testing.T) {
 	}
 	defer legacy.Close()
 
-	_ = NewXlayerHybridTransactionAPI(nil, legacy)
+	_ = NewXlayerHybridTransactionAPI(nil, legacy, nil)
 
 	t.Run("GetTransactionByHash - fallback to Erigon", func(t *testing.T) {
 		// Direct call to Erigon to verify it works
@@ -1426,7 +1426,7 @@ func TestWrapAPIsForXlayer(t *testing.T) {
 			},
 		}
 
-		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy)
+		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy, nil)
 		if len(wrappedAPIs) != 1 {
 			t.Fatalf("expected 1 API, got %d", len(wrappedAPIs))
 		}
@@ -1460,7 +1460,7 @@ func TestWrapAPIsForXlayer(t *testing.T) {
 			},
 		}
 
-		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy)
+		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy, nil)
 		if len(wrappedAPIs) != 1 {
 			t.Fatalf("expected 1 API, got %d", len(wrappedAPIs))
 		}
@@ -1485,7 +1485,7 @@ func TestWrapAPIsForXlayer(t *testing.T) {
 			},
 		}
 
-		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy)
+		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy, nil)
 		if len(wrappedAPIs) != 1 {
 			t.Fatalf("expected 1 API, got %d", len(wrappedAPIs))
 		}
@@ -1507,7 +1507,7 @@ func TestWrapAPIsForXlayer(t *testing.T) {
 			},
 		}
 
-		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy)
+		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy, nil)
 		if len(wrappedAPIs) != 1 {
 			t.Fatalf("expected 1 API, got %d", len(wrappedAPIs))
 		}
@@ -1532,7 +1532,7 @@ func TestWrapAPIsForXlayer(t *testing.T) {
 			},
 		}
 
-		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy)
+		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy, nil)
 		if len(wrappedAPIs) != 1 {
 			t.Fatalf("expected 1 API, got %d", len(wrappedAPIs))
 		}
@@ -1552,7 +1552,7 @@ func TestWrapAPIsForXlayer(t *testing.T) {
 			{Namespace: "debug", Service: &struct{}{}, Public: false},
 		}
 
-		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy)
+		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy, nil)
 		if len(wrappedAPIs) != 5 {
 			t.Fatalf("expected 5 APIs, got %d", len(wrappedAPIs))
 		}
@@ -1584,7 +1584,7 @@ func TestWrapAPIsForXlayer(t *testing.T) {
 			{Namespace: "eth", Service: &ethapi.BlockChainAPI{}, Public: true},
 		}
 
-		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, nil)
+		wrappedAPIs := WrapAPIsForXlayer(originalAPIs, legacy, nil)
 		if len(wrappedAPIs) != 1 {
 			t.Fatalf("expected 1 API, got %d", len(wrappedAPIs))
 		}
@@ -1621,7 +1621,7 @@ func TestTransactionAPI_AdditionalMethods(t *testing.T) {
 	}
 	defer legacy.Close()
 
-	api := NewXlayerHybridTransactionAPI(nil, legacy)
+	api := NewXlayerHybridTransactionAPI(nil, legacy, nil)
 	ctx := context.Background()
 
 	t.Run("GetTransactionCount - FORWARD strategy", func(t *testing.T) {
@@ -2042,7 +2042,7 @@ func TestNilLegacyService(t *testing.T) {
 			{Namespace: "eth", Service: originalAPI, Public: true},
 		}
 
-		wrapped := WrapAPIsForXlayer(apis, nil)
+		wrapped := WrapAPIsForXlayer(apis, nil, nil)
 		if len(wrapped) != 1 {
 			t.Fatalf("expected 1 API, got %d", len(wrapped))
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -540,7 +540,7 @@ func (s *Ethereum) APIs() []rpc.API {
 
 	// Xlayer: Wrap APIs with migration routing if configured
 	if s.xlayerLegacyRPCService != nil {
-		apis = WrapAPIsForXlayer(apis, s.xlayerLegacyRPCService)
+		apis = WrapAPIsForXlayer(apis, s.xlayerLegacyRPCService, s.APIBackend)
 	}
 
 	// Append any Sequencer APIs as enabled

--- a/internal/ethapi/api_xlayer.go
+++ b/internal/ethapi/api_xlayer.go
@@ -32,13 +32,24 @@ func (api *TransactionAPI) GetInternalTransactions(ctx context.Context, txHash c
 }
 
 // GetBlockInternalTransactions returns all inner transactions for all transactions in a block
-func (api *TransactionAPI) GetBlockInternalTransactions(ctx context.Context, blockNr rpc.BlockNumber) (map[common.Hash][]*types.InnerTx, error) {
+func (api *TransactionAPI) GetBlockInternalTransactions(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (map[common.Hash][]*types.InnerTx, error) {
 	// Check if inner transaction feature is enabled
 	if xlayerBackend, ok := api.b.(XLayerBackend); ok && !xlayerBackend.IsInnerTxEnabled() {
 		return nil, errors.New("unsupported internal transaction method")
 	}
 
-	block, err := api.b.BlockByNumber(ctx, blockNr)
+	// Get block by number or hash
+	var block *types.Block
+	var err error
+
+	if blockNum, ok := blockNrOrHash.Number(); ok {
+		block, err = api.b.BlockByNumber(ctx, blockNum)
+	} else if blockHash, ok := blockNrOrHash.Hash(); ok {
+		block, err = api.b.BlockByHash(ctx, blockHash)
+	} else {
+		return nil, errors.New("invalid block number or hash")
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block: %w", err)
 	}

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -362,7 +362,6 @@ func TestEthereumBlockRPC(t *testing.T) {
 		for _, receipt := range receiptsByNumber {
 			require.NoError(t, err)
 			require.NotNil(t, receipt)
-			log.Info(fmt.Sprintf("RealtimeGetBlockReceiptsByNumber result type: %T", receipt))
 		}
 
 		// Test getting receipts by hash
@@ -372,7 +371,6 @@ func TestEthereumBlockRPC(t *testing.T) {
 		for _, receipt := range receiptsByHash {
 			require.NoError(t, err)
 			require.NotNil(t, receipt)
-			log.Info(fmt.Sprintf("RealtimeGetBlockReceiptsByHash result type: %T", receipt))
 		}
 	})
 }
@@ -755,7 +753,10 @@ func TestInnerTx(t *testing.T) {
 		txHashes := TransTokenBatch(t, ctx, client, uint256.NewInt(params.GWei), operations.DefaultL2NewAcc1Address, 5, operations.DefaultRichPrivateKey)
 		require.Len(t, txHashes, 5, "Should have created 5 transactions")
 
-		blockNumbers := make(map[uint64][]int)
+		blockInfo := make(map[uint64]struct {
+			hash      common.Hash
+			txIndices []int
+		})
 
 		for i, txHashStr := range txHashes {
 			txHash := common.HexToHash(txHashStr)
@@ -763,42 +764,71 @@ func TestInnerTx(t *testing.T) {
 			require.NoError(t, err, "Failed to get receipt for tx %d", i)
 
 			blockNum := receipt.BlockNumber.Uint64()
-			blockNumbers[blockNum] = append(blockNumbers[blockNum], i)
+			blockHash := receipt.BlockHash
+
+			info := blockInfo[blockNum]
+			info.hash = blockHash
+			info.txIndices = append(info.txIndices, i)
+			blockInfo[blockNum] = info
 		}
 
 		totalValidatedTxs := 0
 
-		for blockNum, txIndices := range blockNumbers {
-			fmt.Printf("Testing block %d with %d transactions\n", blockNum, len(txIndices))
+		for blockNum, info := range blockInfo {
+			fmt.Printf("Testing block %d (hash %s) with %d transactions\n", blockNum, info.hash.Hex(), len(info.txIndices))
 
-			blockInnerTxs, err := operations.EthGetBlockInternalTransactions(rpc.BlockNumber(blockNum))
+			// Query by block number
+			blockNrOrHash_Num := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum))
+			blockInnerTxsByNum, err := operations.EthGetBlockInternalTransactions(blockNrOrHash_Num)
 			require.NoError(t, err, "Failed to get block internal transactions for block %d", blockNum)
-			require.NotNil(t, blockInnerTxs, "Block inner transactions should not be nil for block %d", blockNum)
+			require.NotNil(t, blockInnerTxsByNum, "Block inner transactions should not be nil for block %d", blockNum)
+
+			// Query by block hash
+			blockNrOrHash_Hash := rpc.BlockNumberOrHashWithHash(info.hash, false)
+			blockInnerTxsByHash, err := operations.EthGetBlockInternalTransactions(blockNrOrHash_Hash)
+			require.NoError(t, err, "Failed to get block internal transactions for block hash %s", info.hash.Hex())
+			require.NotNil(t, blockInnerTxsByHash, "Block inner transactions should not be nil for block hash %s", info.hash.Hex())
+
+			// Verify both queries return exactly the same results
+			require.Equal(t, blockInnerTxsByNum, blockInnerTxsByHash,
+				"Block number and block hash queries should return identical results for block %d", blockNum)
 
 			// Verify all transactions in this block are present in block internal transactions
 			batchTxsInBlock := 0
-			for _, txIdx := range txIndices {
+			for _, txIdx := range info.txIndices {
 				txHash := common.HexToHash(txHashes[txIdx])
-				blockInnerTxsForTx, exists := blockInnerTxs[txHash]
-				require.True(t, exists, "Transaction %d (%s) should be in block %d internal transactions", txIdx, txHashes[txIdx], blockNum)
-				require.Len(t, blockInnerTxsForTx, 1, "Transaction %d should have exactly 1 inner transaction", txIdx)
+
+				// Check transaction exists in results from block number query
+				blockInnerTxsForTxByNum, existsByNum := blockInnerTxsByNum[txHash]
+				require.True(t, existsByNum, "Transaction %d (%s) should be in block %d internal transactions (by number)", txIdx, txHashes[txIdx], blockNum)
+				require.Len(t, blockInnerTxsForTxByNum, 1, "Transaction %d should have exactly 1 inner transaction (by number)", txIdx)
+
+				// Check transaction exists in results from block hash query
+				blockInnerTxsForTxByHash, existsByHash := blockInnerTxsByHash[txHash]
+				require.True(t, existsByHash, "Transaction %d (%s) should be in block hash %s internal transactions", txIdx, txHashes[txIdx], info.hash.Hex())
+				require.Len(t, blockInnerTxsForTxByHash, 1, "Transaction %d should have exactly 1 inner transaction (by hash)", txIdx)
+
 				batchTxsInBlock++
 
-				innerTx := blockInnerTxsForTx[0]
+				innerTxByNum := blockInnerTxsForTxByNum[0]
+				innerTxByHash := blockInnerTxsForTxByHash[0]
+
+				// Verify inner transactions from both queries match
+				ValidateInnerTransactionMatch(t, innerTxByNum, innerTxByHash, fmt.Sprintf("batch tx %d: block number vs block hash", txIdx))
 
 				// Compare with individual transaction inner transactions
 				individualInnerTxs, err := operations.EthGetInternalTransactions(txHash)
 				require.NoError(t, err, "Failed to get individual inner transactions for tx %d", txIdx)
 				require.Len(t, individualInnerTxs, 1, "Individual inner transactions should have 1 entry for tx %d", txIdx)
 
-				ValidateInnerTransactionMatch(t, individualInnerTxs[0], innerTx, fmt.Sprintf("batch tx %d comparison", txIdx))
+				ValidateInnerTransactionMatch(t, individualInnerTxs[0], innerTxByNum, fmt.Sprintf("batch tx %d comparison", txIdx))
 			}
 
 			totalValidatedTxs += batchTxsInBlock
 		}
 
 		require.Equal(t, len(txHashes), totalValidatedTxs, "Should have validated all batch transactions")
-		fmt.Printf("Successfully validated all %d transactions across %d blocks\n", totalValidatedTxs, len(blockNumbers))
+		fmt.Printf("Successfully validated all %d transactions across %d blocks (by both number and hash)\n", totalValidatedTxs, len(blockInfo))
 	})
 
 	t.Run("GetInnerTransactions_FailedTransactions", func(t *testing.T) {
@@ -845,13 +875,15 @@ func TestInnerTx(t *testing.T) {
 
 	t.Run("SpecialBlockNumberFormats", func(t *testing.T) {
 		// Test "latest" format
-		latestResult, err := operations.EthGetBlockInternalTransactions(rpc.LatestBlockNumber)
+		latestBlockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		latestResult, err := operations.EthGetBlockInternalTransactions(latestBlockNrOrHash)
 		require.NoError(t, err)
 		require.NotNil(t, latestResult, "Latest block should return a valid map")
 		fmt.Printf("'latest' block contains %d transactions with inner transactions\n", len(latestResult))
 
 		// Test "earliest" format
-		earliestResult, err := operations.EthGetBlockInternalTransactions(rpc.EarliestBlockNumber)
+		earliestBlockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.EarliestBlockNumber)
+		earliestResult, err := operations.EthGetBlockInternalTransactions(earliestBlockNrOrHash)
 		require.NoError(t, err)
 		require.NotNil(t, earliestResult, "Earliest block should return a valid map")
 		fmt.Printf("'earliest' block contains %d transactions with inner transactions\n", len(earliestResult))

--- a/test/operations/rpc_all.go
+++ b/test/operations/rpc_all.go
@@ -476,13 +476,13 @@ func EthGetInternalTransactions(txHash common.Hash) ([]*types.InnerTx, error) {
 }
 
 // EthGetBlockInternalTransactions returns the internal transactions for a given block number
-func EthGetBlockInternalTransactions(blockNumber rpc.BlockNumber) (map[common.Hash][]*types.InnerTx, error) {
+func EthGetBlockInternalTransactions(blockNumberOrHash rpc.BlockNumberOrHash) (map[common.Hash][]*types.InnerTx, error) {
 
 	var result map[common.Hash][]*types.InnerTx
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	err := clientRPC.Client().CallContext(ctx, &result, "eth_getBlockInternalTransactions", blockNumber)
+	err := clientRPC.Client().CallContext(ctx, &result, "eth_getBlockInternalTransactions", blockNumberOrHash)
 	if err != nil {
 		return nil, err
 	}

--- a/test/operations/rpc_client.go
+++ b/test/operations/rpc_client.go
@@ -126,32 +126,6 @@ func GetInternalTransactions(hash common.Hash) ([]interface{}, error) {
 	return result, nil
 }
 
-func GetBlockInternalTransactions(block *big.Int) (map[common.Hash][]interface{}, error) {
-	var result map[common.Hash][]interface{}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	err := clientRPC.Client().CallContext(ctx, &result, "eth_getBlockInternalTransactions", hexutil.EncodeBig(block))
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
-func GetTransactionByHash(hash common.Hash) (*types.Transaction, error) {
-	var result types.Transaction
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	err := clientRPC.Client().CallContext(ctx, &result, "eth_getTransactionByHash", hash)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result, nil
-}
-
 func GetGasPrice() (uint64, error) {
 	var result string
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
## Summary
This PR supports the use of block hash to query block inner transactions in addition to block number. However, on Erigon the `eth_getBlockInternalTransactions` only supports block number. Hence, for legacy APIs, there is a need to convert it to blocknumber before sending it over to Erigon RPC.

## Flow for legacy API
1. If a block number is provided:
   - Check whether the request needs to be proxied to the Erigon RPC.
      - If yes, make an RPC call to Erigon using the provided block number.
      - If not, call the original `GetBlockInternalTransactions` RPC method in op-geth.

2. If a block hash is provided instead:
   - Attempt to convert the block hash to a block number.
      - If the block number exists in op-geth, call the original `GetBlockInternalTransactions` RPC method in op-geth.
      - If not, look up the block in Erigon using the block hash, convert it to a block number, and then call the `GetBlockInternalTransactions` RPC method in Erigon.