### PR TITLE
fix(ancientdb): fix the error of starting up on testnet data

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -40,7 +40,6 @@ func ReadCanonicalHash(db ethdb.Reader, number uint64) common.Hash {
 		data, _ = reader.Ancient(ChainFreezerHashTable, number)
 		if len(data) == 0 {
 			// Get it by hash from leveldb
-			log.Info("ReadCanonicalHash: data not found from ancientdb, reading from leveldb", "number", number)
 			data, _ = db.Get(headerHashKey(number))
 		}
 		return nil


### PR DESCRIPTION
This pull request introduces a recovery mechanism for the genesis block in the database initialization process, specifically targeting scenarios where the genesis block might be missing from LevelDB but present in the freezer (ancient) database. This ensures data integrity for XLayer testnet migrations and improves robustness during database validation and opening.

### Genesis Block Recovery Enhancements

* Added the `restoreGenesisBlockFromFreezerForXLayer` function to move the genesis block and its associated data from the freezer (ancientdb) to LevelDB if it's missing, including block header, body, receipts, and chain config.
* Integrated the genesis block restoration step into the database opening sequence, ensuring it runs before validation and other checks.

### Chain Validation Logic Updates

* Updated chain validation logic to account for XLayer-specific conditions, using chain config to determine when to validate the head block range and freezer boundaries.

### Dependency Additions

* Imported new dependencies required for block decoding and manipulation: `github.com/ethereum/go-ethereum/core/types` and `github.com/ethereum/go-ethereum/rlp`.



### Fixed bugs

Bug1: 
* When: Stop geth during first starting up(less than 5s) and restart, will cause the error below
* Cause: Because ancient db writing not finished.
```
Chain metadata
  databaseVersion: 9 (0x9)
  headBlockHash: 0xcf6d91419c8a642493c34f0fe6f4ffa52f08cbf51e255adc377e459c1318351a
  headFastBlockHash: 0xcf6d91419c8a642493c34f0fe6f4ffa52f08cbf51e255adc377e459c1318351a
  headHeaderHash: 0xcf6d91419c8a642493c34f0fe6f4ffa52f08cbf51e255adc377e459c1318351a
  lastPivotNumber: <nil>
  len(snapshotSyncStatus): 0 bytes
  snapshotDisabled: false
  snapshotJournal: 34 bytes
  snapshotRecoveryNumber: <nil>
  snapshotRoot: 0x1bea7a842c84d49eeda97a86d769a2381eb7b74642175231f1c4641590a1cf3c
  txIndexTail: 10909925 (0xa678e5)
  filterMapsRange: {Version:2 HeadIndexed:true HeadDelimiter:0 BlocksFirst:0 BlocksAfterLast:10909926 MapsFirst:0 MapsAfterLast:1 TailPartialEpoch:0}


Fatal: Failed to register the Ethereum service: gap in the chain between ancients [0 - #10489926] and db [#10909925 - #10909925]
```

Bug2:
* When: Use our latest testnet data to startup, cause the problems below. 
* Cause: Because geth could not get hash of block 0 from db. It has been frozen to ancient db.
```
[signal SIGSEGV: segmentation violation code=0x2 addr=0x88 pc=0x100552368]

goroutine 7020 [running]:
github.com/ethereum/go-ethereum/params.(*ChainConfig).IsXLayer(0x1015a4ebd?)
	/Users/jimmyshi/code/op-geth/params/config.go:949 +0x18
github.com/ethereum/go-ethereum/core/rawdb.(*chainFreezer).freezeRange.func1({0x10287b500, 0x1400131d4d8})
	/Users/jimmyshi/code/op-geth/core/rawdb/chain_freezer.go:320 +0x1ac
github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).ModifyAncients(0x14000417180, 0x1400120e000)
	/Users/jimmyshi/code/op-geth/core/rawdb/freezer.go:259 +0x164
github.com/ethereum/go-ethereum/core/rawdb.(*chainFreezer).ModifyAncients(...)
	/Users/jimmyshi/code/op-geth/core/rawdb/chain_freezer.go:430
github.com/ethereum/go-ethereum/core/rawdb.(*chainFreezer).freezeRange(0x1400148c100, 0x14000588020, 0xb5cdab, 0xb642da)
	/Users/jimmyshi/code/op-geth/core/rawdb/chain_freezer.go:311 +0x134
github.com/ethereum/go-ethereum/core/rawdb.(*chainFreezer).freeze(0x1400148c100, {0x102894fb0, 0x14000103dc0})
	/Users/jimmyshi/code/op-geth/core/rawdb/chain_freezer.go:213 +0x380
github.com/ethereum/go-ethereum/core/rawdb.Open.func1()
	/Users/jimmyshi/code/op-geth/core/rawdb/database.go:330 +0x2c
created by github.com/ethereum/go-ethereum/core/rawdb.Open in goroutine 1
	/Users/jimmyshi/code/op-geth/core/rawdb/database.go:329 +0x4b8
```