### PR TITLE
Fix: Change GasUsed field

### DIFF
--- a/eth/api_pre_exec_xlayer.go
+++ b/eth/api_pre_exec_xlayer.go
@@ -367,12 +367,11 @@ func convertCallToInnerTxsRecursive(callTx CallTracerResult, depth int64, index 
 		Input:         callTx.Input,
 		Output:        output,
 		IsError:       isError,
-		// GasUsed:       gasUsedUint64,  // For historical reason, we use gasUint64 here
-		GasUsed:   gasUint64,
-		Value:     valueWei,
-		ValueWei:  valueWei,
-		Error:     errorMsg,
-		ReturnGas: returnGas,
+		GasUsed:       gasUsedUint64,
+		Value:         valueWei,
+		ValueWei:      valueWei,
+		Error:         errorMsg,
+		ReturnGas:     returnGas,
 	}
 
 	// Handle root vs nested call differences


### PR DESCRIPTION
## Summary
- Revert the changes made to `GasUsed` field to be aligned with the node team's new implementation. Previously the node team's implementation had incorrectly set `gas` as `gasUsed` but that has since been fixed.