### PR TITLE
fix: ensure no error using websocket with fromBlock parameter smaller than migration block

### DIFF
--- a/eth/api_legacy_xlayer.go
+++ b/eth/api_legacy_xlayer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/internal/ethapi/override"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -763,6 +764,7 @@ func (api *XlayerHybridFilterAPI) GetLogs(ctx context.Context, crit filters.Filt
 func (api *XlayerHybridFilterAPI) Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc.Subscription, error) {
 	migrationBlock := int64(api.legacyRpc.MigrationBlock)
 	if crit.FromBlock != nil && crit.FromBlock.Int64() < migrationBlock {
+		log.Warn("Parameter fromBlock is earlier than migration block, overwriting fromBlock to migrationBlock", "fromBlock", crit.FromBlock.Int64(), "migrationBlock", migrationBlock)
 		crit.FromBlock = big.NewInt(migrationBlock)
 	}
 


### PR DESCRIPTION
# Summary 
Even though the `fromBlock` parameter is ignored for eth_subscribe (https://github.com/web3/web3.js/issues/1307, https://geth.ethereum.org/docs/interacting-with-geth/rpc/pubsub), using a `fromBlock` that is smaller than the migration block will return an error. 

<img width="379" height="147" alt="image" src="https://github.com/user-attachments/assets/1a698945-0fde-48fd-be3d-9e9da8dceeea" />

The PR fixes it by overwriting the `fromBlock` parameter with `migrationBlock` if the value is smaller than the migration block
