### PR TITLE
fix: linting errors

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -154,7 +154,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 // and uses the input parameters for its environment similar to ApplyTransaction. However,
 // this method takes an already created EVM instance as input.
 func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, blockTime uint64, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (receipt *types.Receipt, err error) {
-
 	if hooks := evm.Config.Tracer; hooks != nil {
 		if hooks.OnTxStart != nil {
 			hooks.OnTxStart(evm.GetVMContext(), tx, msg.From)

--- a/eth/api_legacy_xlayer_test.go
+++ b/eth/api_legacy_xlayer_test.go
@@ -855,7 +855,7 @@ func TestBoundaryConditions_MigrationBlock(t *testing.T) {
 			// Test GetBlockByNumber routing
 			if tc.shouldProxy {
 				// Should call Erigon
-				res, err := api.GetBlockByNumber(ctx, rpc.BlockNumber(tc.blockNum), false)
+				res, err := api.GetBlockByNumber(ctx, tc.blockNum, false)
 				if err != nil {
 					t.Fatalf("GetBlockByNumber(%d) failed: %v", tc.blockNum, err)
 				}
@@ -1049,25 +1049,8 @@ func TestShouldProxyBlockNrOrHash(t *testing.T) {
 	}
 }
 
-// testHeaderByHashGetter implements the headerByHashGetter interface for testing
-type testHeaderByHashGetter struct {
-	headers map[common.Hash]map[string]interface{}
-}
-
-func (t *testHeaderByHashGetter) GetHeaderByHash(ctx context.Context, hash common.Hash) map[string]interface{} {
-	if headerData, ok := t.headers[hash]; ok {
-		return headerData
-	}
-	return nil
-}
-
 func makeBlockNumberOrHash(num rpc.BlockNumber) *rpc.BlockNumberOrHash {
 	result := rpc.BlockNumberOrHashWithNumber(num)
-	return &result
-}
-
-func makeBlockHash(hash common.Hash) *rpc.BlockNumberOrHash {
-	result := rpc.BlockNumberOrHashWithHash(hash, false)
 	return &result
 }
 


### PR DESCRIPTION
## Summary
- This PR fixes the linting errors caused by the changes made in this other PR https://github.com/okx/op-geth/pull/133

## Changes
- Remove unused functions 
- Remove unnecessary type conversions
- Remove unnecessary new line in function