### PR TITLE
chore: Refactor getInternalTransactions in legacy API

### DIFF
--- a/eth/api_legacy_xlayer.go
+++ b/eth/api_legacy_xlayer.go
@@ -100,10 +100,7 @@ func (api *XlayerHybridBlockChainAPI) shouldProxy(ctx context.Context, bNrOrHash
 
 	if hash, ok := bNrOrHash.Hash(); ok {
 		header := api.BlockChainAPI.GetHeaderByHash(ctx, hash)
-		if header != nil {
-			return false
-		}
-		return true
+		return header == nil
 	}
 
 	return false


### PR DESCRIPTION
## Summary
- This PR refactors the logic that determines whether a request should be forwarded to the legacy Erigon RPC, making it more deterministic and independent of output-based checks. 
## Changes
- For `eth_getInternalTransactions`, we first check if the transaction hash exists locally by calling `getTransactionByHash`
   - If transaction exists locally, we will send the request locally
   - Else, we will forward the request to Erigon RPC 