### PR TITLE
fix: fork id should be xlayer version in discovery

### DIFF
--- a/eth/protocols/eth/discovery.go
+++ b/eth/protocols/eth/discovery.go
@@ -62,7 +62,7 @@ func StartENRUpdater(chain *core.BlockChain, ln *enode.LocalNode) {
 func currentENREntry(chain *core.BlockChain) *enrEntry {
 	head := chain.CurrentHeader()
 	return &enrEntry{
-		ForkID: forkid.NewID(chain.Config(), chain.Genesis(), head.Number.Uint64(), head.Time),
+		ForkID: forkid.NewIDXLayer(chain.Config(), chain.GenesisXLayer(), head.Number.Uint64(), head.Time),
 	}
 }
 


### PR DESCRIPTION
It's about discovery new node in discv4/discv5.