### PR TITLE
chore: update chainid

### DIFF
--- a/test/operations/manager.go
+++ b/test/operations/manager.go
@@ -23,7 +23,7 @@ const (
 
 	DefaultL2NetworkURL        = "http://localhost:8124"
 	DefaultL2SeqURL            = "http://localhost:8123"
-	DefaultL2ChainID    uint64 = 196
+	DefaultL2ChainID    uint64 = 195
 
 	DefaultL2MetricsPrometheusURL = "http://127.0.0.1:9092/debug/metrics/prometheus"
 	DefaultL2MetricsURL           = "http://127.0.0.1:9092/debug/metrics"


### PR DESCRIPTION
## Summary
This PR updates the `DefaultL2ChainID` to 195 to be consistent with the chainid used in op-stack.