### PR TITLE
refactor: expose interface & handle custom genesis number logic

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"errors"

--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"os"

--- a/cmd/geth/attach_test.go
+++ b/cmd/geth/attach_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"fmt"

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"encoding/json"

--- a/cmd/geth/chaincmd_test.go
+++ b/cmd/geth/chaincmd_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import "testing"
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"bufio"

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"fmt"

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"crypto/rand"

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"bytes"

--- a/cmd/geth/exportcmd_test.go
+++ b/cmd/geth/exportcmd_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"bytes"

--- a/cmd/geth/ext_xlayer.go
+++ b/cmd/geth/ext_xlayer.go
@@ -1,0 +1,46 @@
+// Copyright 2025 The xlayer-geth Authors
+// This file is part of xlayer-geth.
+//
+// xlayer-geth is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// xlayer-geth is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with xlayer-geth. If not, see <http://www.gnu.org/licenses/>.
+
+package gethmain
+
+import (
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/urfave/cli/v2"
+)
+
+// Exposed variables for xlayer-geth
+var (
+	App          = app          // CLI application
+	NodeFlags    = nodeFlags    // Node configuration flags
+	RPCFlags     = rpcFlags     // RPC configuration flags
+	MetricsFlags = metricsFlags // Metrics configuration flags
+	ConsoleFlags = consoleFlags // Console configuration flags
+)
+
+// Prepare exposes the prepare function for xlayer-geth
+func Prepare(ctx *cli.Context) {
+	prepare(ctx)
+}
+
+// MakeFullNode exposes the makeFullNode function for xlayer-geth
+func MakeFullNode(ctx *cli.Context) *node.Node {
+	return makeFullNode(ctx)
+}
+
+// StartNode exposes the startNode function for xlayer-geth
+func StartNode(ctx *cli.Context, stack *node.Node, isConsole bool) {
+	startNode(ctx, stack, isConsole)
+}

--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"fmt"

--- a/cmd/geth/logging_test.go
+++ b/cmd/geth/logging_test.go
@@ -16,7 +16,7 @@
 
 //go:build integrationtests
 
-package main
+package gethmain
 
 import (
 	"bufio"

--- a/cmd/geth/logtestcmd_active.go
+++ b/cmd/geth/logtestcmd_active.go
@@ -16,7 +16,7 @@
 
 //go:build integrationtests
 
-package main
+package gethmain
 
 import (
 	"errors"

--- a/cmd/geth/logtestcmd_inactive.go
+++ b/cmd/geth/logtestcmd_inactive.go
@@ -16,7 +16,7 @@
 
 //go:build !integrationtests
 
-package main
+package gethmain
 
 import "github.com/urfave/cli/v2"
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -15,7 +15,7 @@
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
 // geth is a command-line client for Ethereum.
-package main
+package gethmain
 
 import (
 	"fmt"
@@ -306,7 +306,7 @@ func init() {
 	}
 }
 
-func main() {
+func Main() {
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"fmt"

--- a/cmd/geth/run_test.go
+++ b/cmd/geth/run_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"context"

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"bytes"

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"bytes"

--- a/cmd/geth/version_check.go
+++ b/cmd/geth/version_check.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"encoding/json"

--- a/cmd/geth/version_check_test.go
+++ b/cmd/geth/version_check_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package main
+package gethmain
 
 import (
 	"encoding/json"

--- a/core/filtermaps/filtermaps.go
+++ b/core/filtermaps/filtermaps.go
@@ -393,7 +393,7 @@ func (f *FilterMaps) init() error {
 			bestIdx, bestLen = idx, max
 		}
 	}
-	var initBlockNumber uint64
+	initBlockNumber := f.historyCutoff
 	if bestLen > 0 {
 		initBlockNumber = checkpoints[bestIdx][bestLen-1].BlockNumber
 	}
@@ -503,7 +503,7 @@ func (f *FilterMaps) getLogByLvIndex(lvIndex uint64) (*types.Log, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve last block of map %d containing searched log value index %d: %v", mapIndex, lvIndex, err)
 	}
-	var firstBlockNumber uint64
+	firstBlockNumber := f.historyCutoff
 	if mapIndex > 0 {
 		firstBlockNumber, _, err = f.getLastBlockOfMap(mapIndex - 1)
 		if err != nil {
@@ -763,7 +763,7 @@ func (f *FilterMaps) deleteTailEpoch(epoch uint32) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to retrieve last block of deleted epoch %d: %v", epoch, err)
 	}
-	var firstBlock uint64
+	firstBlock := f.historyCutoff
 	firstMap := f.firstEpochMap(epoch)
 	if epoch > 0 {
 		firstBlock, _, err = f.getLastBlockOfMap(firstMap - 1)

--- a/core/filtermaps/map_renderer.go
+++ b/core/filtermaps/map_renderer.go
@@ -161,13 +161,13 @@ func (f *FilterMaps) lastCanonicalSnapshotOfMap(mapIndex uint32) *renderedMap {
 // and starting log value pointer of the last block is also returned.
 func (f *FilterMaps) lastCanonicalMapBoundaryBefore(renderBefore uint32) (nextMap uint32, startBlock, startLvPtr uint64, err error) {
 	if !f.indexedRange.initialized {
-		return 0, 0, 0, nil
+		return 0, f.historyCutoff, 0, nil
 	}
 	mapIndex := renderBefore
 	for {
 		var ok bool
 		if mapIndex, ok = f.lastMapBoundaryBefore(mapIndex); !ok {
-			return 0, 0, 0, nil
+			return 0, f.historyCutoff, 0, nil
 		}
 		lastBlock, lastBlockId, err := f.getLastBlockOfMap(mapIndex)
 		if err != nil {
@@ -229,7 +229,7 @@ func (f *FilterMaps) loadHeadSnapshot() error {
 	if err != nil {
 		return fmt.Errorf("failed to retrieve last block of head snapshot map %d: %v", f.indexedRange.maps.Last(), err)
 	}
-	var firstBlock uint64
+	var firstBlock uint64 = f.historyCutoff
 	if f.indexedRange.maps.AfterLast() > 1 {
 		prevLastBlock, _, err := f.getLastBlockOfMap(f.indexedRange.maps.Last() - 1)
 		if err != nil {
@@ -468,7 +468,7 @@ func (r *mapRenderer) writeFinishedMaps(pauseCb func() bool) error {
 			r.f.filterMapCache.Remove(mapIndex)
 		}
 	}
-	var blockNumber uint64
+	blockNumber := r.f.historyCutoff
 	if r.finished.First() > 0 {
 		// in order to always ensure continuous block pointers, initialize
 		// blockNumber based on the last block of the previous map, then verify

--- a/core/rawdb/ext_xlayer.go
+++ b/core/rawdb/ext_xlayer.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The xlayer-geth Authors
+// This file is part of xlayer-geth.
+//
+// xlayer-geth is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// xlayer-geth is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with xlayer-geth. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// ReadChainConfigRaw reads the raw chain config JSON data from database
+// This is exposed for xlayer-geth to decode only the fields it needs
+func ReadChainConfigRaw(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
+	data, err := db.Get(configKey(hash))
+	return data, err
+}
+

--- a/node/ext_xlayer.go
+++ b/node/ext_xlayer.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The xlayer-geth Authors
+// This file is part of xlayer-geth.
+//
+// xlayer-geth is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// xlayer-geth is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with xlayer-geth. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+// Lifecycles exposes the lifecycles for xlayer-geth
+// This allows xlayer-geth to access registered services like the Ethereum backend
+func (n *Node) Lifecycles() []Lifecycle {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	return n.lifecycles
+}


### PR DESCRIPTION
This pull request refactors the `cmd/geth` package by renaming the main package from `main` to `gethmain` across all relevant source and test files. Additionally, it introduces a new file, `ext_xlayer.go`, which exposes key internal functions and variables for external use, and renames the main entrypoint function to `Main`. These changes improve modularity and make it easier to embed or reuse the `geth` command logic in other projects or binaries.

### Package Refactoring

* Changed the package declaration from `main` to `gethmain` in all source and test files under `cmd/geth`, including but not limited to `main.go`, `accountcmd.go`, `chaincmd.go`, `config.go`, `consolecmd.go`, `dbcmd.go`, `misccmd.go`, `snapshot.go`, `verkle.go`, and all corresponding test files. This change improves code modularity and allows the package to be imported elsewhere. [[1]](diffhunk://#diff-b88439e16a7047ba2ea03a47c8e79974f4c1a9f194b5ec63b50386fc05a18bfeL17-R17) [[2]](diffhunk://#diff-6b509d007625da4ff5a6d09a00e428a5296b53f9e3e6bc7d94e113720ff92b31L17-R17) [[3]](diffhunk://#diff-188587ca0db4de60573f7d8163de8d4954770c29ca79485569f81a9d2f80ee18L17-R17) [[4]](diffhunk://#diff-f0fd3235d22fb95cd73f1073467ac23397e9fc949e359fccb3ad0ff278dfac5eL17-R17) [[5]](diffhunk://#diff-cb7778651ecb5227a890bd7f2f0fefdcc22afbe4277f3bacdd8326c4810683e8L17-R17) [[6]](diffhunk://#diff-efb34882aeb5938c3c2527733e914b31697acefcdccc3b3c42467fda64efc362L17-R17) [[7]](diffhunk://#diff-374d79e89070f6051b0a88e067aeb648557f9ba9a0501b76c0d5836204cab5f4L17-R17) [[8]](diffhunk://#diff-43540acd85c8bf0a762852f8ead8b9e8f0edb6beed83c29d7697c3e21de6f287L17-R17) [[9]](diffhunk://#diff-b17377260117e22987b2b978a970b51a6a6bf8afbc6416242db9f55c589fa2daL17-R17) [[10]](diffhunk://#diff-214d0faa2e724678cc5ecceffdb059c462549905e880c3a34852ed639201707cL17-R17) [[11]](diffhunk://#diff-15c46b496144a0a433ab90e4660e69d756cb00354c5ecbdf6408432d37ca6bc9L17-R17) [[12]](diffhunk://#diff-41f0f27831d5799982238705d76d4afa116cc6126733a809b7c484a290bbfb9bL19-R19) [[13]](diffhunk://#diff-847dcebbbaa1c89c1867e7f7b1c453fde02f81f48e7d9b497d12a399eabd76c0L19-R19) [[14]](diffhunk://#diff-333d176ada693b9068ddd3c9e9ac24c295ab44a17b36fc374345c2e0191ced59L19-R19) [[15]](diffhunk://#diff-30437b401e56caf63af6a19560e47ff5c65bfe20970c044d5c497f2158729b3cL18-R18) [[16]](diffhunk://#diff-087ef80589b4ca3819eb0a17999914c8f4154fa739913919c714b8b765ef452bL17-R17) [[17]](diffhunk://#diff-941418e0e20432abbb256247c1a4f9478d15eb93d950ffff6ae12fd1034aa12dL17-R17) [[18]](diffhunk://#diff-0389642fc7879f5c3dca4f85194689759d0e3a24fca8cc67902b1ea7d559868bL17-R17) [[19]](diffhunk://#diff-7690425ffdb4f510e491bb2b455108123317f1dfb69143dfffdc8abb0403c934L17-R17)

### Public API and Entrypoint Changes

* Added a new file, `ext_xlayer.go`, which exposes key variables and functions (`App`, `NodeFlags`, `RPCFlags`, `MetricsFlags`, `ConsoleFlags`, `Prepare`, `MakeFullNode`, `StartNode`) for external use, facilitating easier integration with other projects such as xlayer-geth.
* Renamed the main entrypoint function from `main()` to `Main()` in `main.go` to allow it to be called externally, rather than being restricted to use as a standalone binary.