### PR TITLE
fix: linting fix on eth package

### DIFF
--- a/eth/protocols/eth/handshake.go
+++ b/eth/protocols/eth/handshake.go
@@ -19,10 +19,10 @@ package eth
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"


### PR DESCRIPTION
## Issue
- linting issues due to incorrect order of imports in `handshake.go` of eth package

## Fix
- re-arrange the imports from `go-ethereum` after the core package imports
